### PR TITLE
Add Octopus Create Release support

### DIFF
--- a/teamcity/build_type_step_test.go
+++ b/teamcity/build_type_step_test.go
@@ -9,14 +9,15 @@ import (
 
 type SuiteBuildTypeSteps struct {
 	suite.Suite
-	TC                     *TestContext
-	BuildTypeContext       *BuildTypeContext
-	BuildTypeID            string
-	StepPowershell         teamcity.Step
-	StepCmdLineExecutable  teamcity.Step
-	StepCmdLineScript      teamcity.Step
-	StepOctopusPushPackage teamcity.Step
-	AddStep                func(teamcity.Step) teamcity.Step
+	TC                       *TestContext
+	BuildTypeContext         *BuildTypeContext
+	BuildTypeID              string
+	StepPowershell           teamcity.Step
+	StepCmdLineExecutable    teamcity.Step
+	StepCmdLineScript        teamcity.Step
+	StepOctopusPushPackage   teamcity.Step
+	StepOctopusCreateRelease teamcity.Step
+	AddStep                  func(teamcity.Step) teamcity.Step
 }
 
 func NewSuiteBuildTypeSteps(t *testing.T) *SuiteBuildTypeSteps {
@@ -32,6 +33,7 @@ func (suite *SuiteBuildTypeSteps) SetupSuite() {
 	`
 	suite.StepCmdLineScript, _ = teamcity.NewStepCommandLineScript("step_exe", script)
 	suite.StepOctopusPushPackage, _ = teamcity.NewStepOctopusPushPackage("Octopus package")
+	suite.StepOctopusCreateRelease, _ = teamcity.NewStepOctopusCreateRelease("Octopus Release")
 }
 
 func (suite *SuiteBuildTypeSteps) SetupTest() {
@@ -63,6 +65,10 @@ func (suite *SuiteBuildTypeSteps) TestAdd_StepCmdLineScript() {
 
 func (suite *SuiteBuildTypeSteps) TestAdd_StepOctopusPushPackage() {
 	suite.AddStep(suite.StepOctopusPushPackage)
+}
+
+func (suite *SuiteBuildTypeSteps) TestAdd_StepOctopusCreateRelease() {
+	suite.AddStep(suite.StepOctopusCreateRelease)
 }
 
 func (suite *SuiteBuildTypeSteps) GetSteps(buildTypeID string) []teamcity.Step {

--- a/teamcity/step.go
+++ b/teamcity/step.go
@@ -14,8 +14,9 @@ const (
 	//StepTypeDotnetCli step type
 	StepTypeDotnetCli BuildStepType = "dotnet.cli"
 	//StepTypeCommandLine (shell/cmd) step type
-	StepTypeCommandLine        BuildStepType = "simpleRunner"
-	StepTypeOctopusPushPackage BuildStepType = "octopus.push.package"
+	StepTypeCommandLine          BuildStepType = "simpleRunner"
+	StepTypeOctopusPushPackage   BuildStepType = "octopus.push.package"
+	StepTypeOctopusCreateRelease BuildStepType = "octopus.create.release"
 )
 
 //StepExecuteMode represents how a build configuration step will execute regarding others.
@@ -84,27 +85,29 @@ var stepReadingFunc = func(dt []byte, out interface{}) error {
 	}
 
 	var step Step
+	var err error
 	switch payload.Type {
 	case string(StepTypePowershell):
 		var ps StepPowershell
-		if err := ps.UnmarshalJSON(dt); err != nil {
-			return err
-		}
+		err = ps.UnmarshalJSON(dt)
 		step = &ps
 	case string(StepTypeCommandLine):
 		var cmd StepCommandLine
-		if err := cmd.UnmarshalJSON(dt); err != nil {
-			return err
-		}
+		err = cmd.UnmarshalJSON(dt)
 		step = &cmd
 	case string(StepTypeOctopusPushPackage):
 		var opp StepOctopusPushPackage
-		if err := opp.UnmarshalJSON(dt); err != nil {
-			return err
-		}
+		err = opp.UnmarshalJSON(dt)
 		step = &opp
+	case string(StepTypeOctopusCreateRelease):
+		var ocr StepOctopusCreateRelease
+		err = ocr.UnmarshalJSON(dt)
+		step = &ocr
 	default:
 		return fmt.Errorf("Unsupported step type: '%s' (id:'%s')", payload.Type, payload.ID)
+	}
+	if err != nil {
+		return err
 	}
 
 	replaceValue(out, &step)

--- a/teamcity/step_octopus_create_release.go
+++ b/teamcity/step_octopus_create_release.go
@@ -89,14 +89,18 @@ func (s *StepOctopusCreateRelease) properties() *Properties {
 	return props
 }
 
-func (s *StepOctopusCreateRelease) MarshalJSON() ([]byte, error) {
-	out := &stepJSON{
+func (s *StepOctopusCreateRelease) serializable() *stepJSON {
+	return &stepJSON{
 		ID:         s.ID,
 		Name:       s.Name,
 		Type:       s.stepType,
 		Properties: s.properties(),
 	}
+}
 
+//MarshalJSON implements JSON serialization for StepOctopusCreateRelease
+func (s *StepOctopusCreateRelease) MarshalJSON() ([]byte, error) {
+	out := s.serializable()
 	return json.Marshal(out)
 }
 

--- a/teamcity/step_octopus_create_release.go
+++ b/teamcity/step_octopus_create_release.go
@@ -1,0 +1,164 @@
+package teamcity
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// StepOctopusPushPackage represents a a build step of type "octopus.create.release"
+type StepOctopusCreateRelease struct {
+	ID       string
+	Name     string
+	stepType string
+	stepJSON *stepJSON
+
+	// Specify Octopus web portal URL.
+	Host string
+
+	// Specify Octopus API key.
+	ApiKey string
+
+	// Specify which version of the Octopus Deploy server you are using.
+	OctopusServerVersion string
+
+	// Name of the Octopus project to create a release for.
+	Project string
+
+	// Number to use for this release.
+	ReleaseNumber string
+
+	// Channel to create the release for.
+	ChannelName string
+
+	// Comma separated list of environments to deploy to.
+	// Leave empty to create a release without deploying it.
+	Environments string
+
+	// Comma separated list of tenants to promote for.
+	// Wildcard '*' will promote all tenants currently able to deploy to the above provided environment.
+	// Note that when supplying tenant filters then only one environment may be provided above.
+	Tenants string
+
+	// Comma separated list of tenant tags that match tenants to deploy for.
+	// Note that when supplying tag filters then only one environment may be provided above.
+	TenantTags string
+
+	//  If true, the build process will only succeed if the deployment is successful.
+	// Output from the deployment will appear in the build output.
+	WaitForDeployments bool
+
+	// Additional arguments to be passed to Octo.exe.
+	AdditionalCommandLineArguments string
+}
+
+func NewStepOctopusCreateRelease(name string) (*StepOctopusCreateRelease, error) {
+	return &StepOctopusCreateRelease{
+		Name:     name,
+		stepType: StepTypeOctopusCreateRelease,
+	}, nil
+}
+
+func (s *StepOctopusCreateRelease) GetID() string {
+	return s.ID
+}
+
+func (s *StepOctopusCreateRelease) GetName() string {
+	return s.Name
+}
+
+func (s *StepOctopusCreateRelease) Type() BuildStepType {
+	return StepTypeOctopusCreateRelease
+}
+
+func (s *StepOctopusCreateRelease) properties() *Properties {
+	props := NewPropertiesEmpty()
+	props.AddOrReplaceValue("teamcity.step.mode", "default")
+	props.AddOrReplaceValue("octopus_host", s.Host)
+	props.AddOrReplaceValue("secure:octopus_apikey", s.ApiKey)
+	props.AddOrReplaceValue("octopus_version", s.OctopusServerVersion)
+	props.AddOrReplaceValue("octopus_project_name", s.Project)
+	props.AddOrReplaceValue("octopus_releasenumber", s.ReleaseNumber)
+	props.AddOrReplaceValue("octopus_channel_name", s.ChannelName)
+	props.AddOrReplaceValue("octopus_deployto", s.Environments)
+	props.AddOrReplaceValue("octoups_tenants", s.Tenants)
+	props.AddOrReplaceValue("octoups_tenanttags", s.TenantTags)
+	props.AddOrReplaceValue("octopus_waitfordeployments", strconv.FormatBool(s.WaitForDeployments))
+	props.AddOrReplaceValue("octopus_additionalcommandlinearguments", s.AdditionalCommandLineArguments)
+
+	return props
+}
+
+func (s *StepOctopusCreateRelease) MarshalJSON() ([]byte, error) {
+	out := &stepJSON{
+		ID:         s.ID,
+		Name:       s.Name,
+		Type:       s.stepType,
+		Properties: s.properties(),
+	}
+
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON implements JSON deserialization for StepOctopusPushPackage
+func (s *StepOctopusCreateRelease) UnmarshalJSON(data []byte) error {
+	var aux stepJSON
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if aux.Type != string(StepTypeOctopusCreateRelease) {
+		return fmt.Errorf("invalid type %s trying to deserialize into StepTypeOctopusCreateRelease entity", aux.Type)
+	}
+	s.Name = aux.Name
+	s.ID = aux.ID
+	s.stepType = StepTypeOctopusCreateRelease
+
+	props := aux.Properties
+	if v, ok := props.GetOk("octopus_host"); ok {
+		s.Host = v
+	}
+
+	if v, ok := props.GetOk("secure:octopus_apikey"); ok {
+		s.ApiKey = v
+	}
+
+	if v, ok := props.GetOk("octopus_version"); ok {
+		s.OctopusServerVersion = v
+	}
+
+	if v, ok := props.GetOk("octopus_project_name"); ok {
+		s.Project = v
+	}
+
+	if v, ok := props.GetOk("octopus_releasenumber"); ok {
+		s.ReleaseNumber = v
+	}
+
+	if v, ok := props.GetOk("octopus_channel_name"); ok {
+		s.ChannelName = v
+	}
+
+	if v, ok := props.GetOk("octopus_deployto"); ok {
+		s.Environments = v
+	}
+
+	if v, ok := props.GetOk("octoups_tenants"); ok {
+		s.Tenants = v
+	}
+
+	if v, ok := props.GetOk("octoups_tenanttags"); ok {
+		s.TenantTags = v
+	}
+
+	if v, ok := props.GetOk("octopus_waitfordeployments"); ok {
+		converted_value, _ := strconv.ParseBool(v)
+		s.WaitForDeployments = converted_value
+	}
+
+	if v, ok := props.GetOk("octopus_additionalcommandlinearguments"); ok {
+		s.AdditionalCommandLineArguments = v
+	}
+
+	return nil
+}

--- a/teamcity/step_octopus_create_release_test.go
+++ b/teamcity/step_octopus_create_release_test.go
@@ -1,0 +1,38 @@
+package teamcity_test
+
+import (
+	"testing"
+
+	teamcity "github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/stretchr/testify/assert"
+)
+
+// Ensure serialization/deserialization works as expected.
+func TestSerialize(t *testing.T) {
+	// Create a StepOctopusCreateRelease object.
+	step, _ := teamcity.NewStepOctopusCreateRelease("Test step")
+	step.Host = "web-14.smith.info"
+	step.ApiKey = "DfkDxZSbSAIpblvdvcTv"
+	step.OctopusServerVersion = "3.0+"
+	step.Project = "Project"
+	step.ReleaseNumber = "1.0.0"
+	step.ChannelName = "Stage"
+	step.Environments = "Stage"
+	step.Tenants = "TenantA"
+	step.TenantTags = ""
+	step.WaitForDeployments = true
+	step.AdditionalCommandLineArguments = ""
+
+	// Serialize the step object.
+	jsonStep, err := step.MarshalJSON()
+	assert.Nil(t, err)
+	assert.NotNil(t, jsonStep)
+
+	// Then deserialize it.
+	deserializeStep, _ := teamcity.NewStepOctopusCreateRelease("Deserialize test step")
+	err = deserializeStep.UnmarshalJSON(jsonStep)
+	assert.Nil(t, err)
+
+	//Ensure it is equal to the original object.
+	assert.Equal(t, step, deserializeStep)
+}

--- a/teamcity/step_octopus_create_release_test.go
+++ b/teamcity/step_octopus_create_release_test.go
@@ -3,7 +3,7 @@ package teamcity_test
 import (
 	"testing"
 
-	teamcity "github.com/cvbarros/go-teamcity-sdk/teamcity"
+	teamcity "github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
This patch implements the support for Octopus
(https://octopus.com/docs/api-and-integration/teamcity). It allows to
define a new type of build step: "octopus.create.release".