### PR TITLE
Rename to go-teamcity and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 #VSCode
 .vscode/
 
+#Goland
+.idea/
+
 # Integration test container dirs
 integration_tests/data_dir/
 integration_tests/log_dir/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   global:
     - GO111MODULE=on
     - TEAMCITY_ADDR=http://localhost:8112
+    - TEAMCITY_VERSION="2018.1.3"
 
 script:
  - make test

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+# 2019-07-30
+**BREAKING CHANGE**: This project now has been renamed from `go-teamcity-sdk` to `go-teamcity`. 
+This will break any imports from `master` as of b267d09410b4aa86910d469f0ef11709ab543ae2.
+
 # 2018-12-20
 BREAKING CHANGE: Moved package code from `pkg/teamcity` to `teamcity`. The former structure caused some issues with tooling such as `gocode` and `godef`.
 Since this project follows [go-github](https://github.com/google/go-github) design and conventions, I've adapted the project structure as well.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Project name.
-PROJECT_NAME = go-teamcity-sdk
+PROJECT_NAME = go-teamcity
 
 # Makefile parameters.
 TAG ?= $(shell git describe)
@@ -18,6 +18,8 @@ CONTAINER_NAME = teamcity_server
 INTEGRATION_TEST_DIR = integration_tests
 TEAMCITY_DATA_DIR = $(INTEGRATION_TEST_DIR)/data_dir
 TEAMCITY_HOST = http://localhost:8112
+TEAMCITY_VERSION ?= "2018.1.3"
+GO111MODULE ?= "on"
 
 default: build
 
@@ -45,11 +47,11 @@ test: ## Run the unit tests
 		-v $(PWD)/$(TEAMCITY_DATA_DIR):/data/teamcity_server/datadir \
 		-v $(PWD)/$(INTEGRATION_TEST_DIR)/log_dir:/opt/teamcity/logs \
 		-p 8112:8111 \
-		jetbrains/teamcity-server:2018.1.3
+		jetbrains/teamcity-server:$(TEAMCITY_VERSION)
 	@echo -n "Teamcity server is booting (this may take a while)..."
 	@until $$(curl -o /dev/null -sfI $(TEAMCITY_HOST)/login.html);do echo -n ".";sleep 5;done
 	@export TEAMCITY_ADDR=$(TEAMCITY_HOST) \
-		&& go test -v -failfast -timeout 60s ./...
+		&& GO111MODULE=$(GO111MODULE) go test -v -failfast -timeout 60s ./...
 
 .PHONY: clean
 clean: clean-code clean-docker ## Clean all resources (!DESTRUCTIVE!)

--- a/README.MD
+++ b/README.MD
@@ -1,18 +1,18 @@
-# go-teamcity-sdk #
+# go-teamcity #
 
-[![GoDoc](https://godoc.org/github.com/cvbarros/go-teamcity-sdk/github?status.svg)](https://godoc.org/github.com/cvbarros/go-teamcity-sdk) [![Build Status](https://travis-ci.org/cvbarros/go-teamcity-sdk.svg?branch=master)](https://travis-ci.org/cvbarros/go-teamcity-sdk)
+[![GoDoc](https://godoc.org/github.com/cvbarros/go-teamcity/github?status.svg)](https://godoc.org/github.com/cvbarros/go-teamcity) [![Build Status](https://travis-ci.org/cvbarros/go-teamcity.svg?branch=master)](https://travis-ci.org/cvbarros/go-teamcity)
 
-go-teamcity-sdk is a Go client library interacting with Jetbrain's [TeamCity CI server REST API](https://confluence.jetbrains.com/display/TCD10/REST+API).
-Currently, supported API version is TeamCity 10.x (2017.2.1) or up.
+go-teamcity is a Go client library interacting with Jetbrain's [TeamCity CI server REST API](https://confluence.jetbrains.com/display/TCD10/REST+API).
+Currently, supported API version is TeamCity 2018.1.3 or up.
 
 ## Motivation ##
-go-teamcity-sdk is intended for automating Jetbrain's TeamCity tasks and configurations using Go.
+go-teamcity is intended for automating Jetbrain's TeamCity tasks and configurations using Go.
 It is also the client library used in [TeamCity Provider](https://github.com/cvbarros/terraform-provider-teamcity), a [Hashicorp's Terraform](https://www.terraform.io) custom provider to configure TeamCity fully in code.
 
 ## Usage ##
 
 ```go
-import teamcity "github.com/cvbarros/go-teamcity-sdk"
+import teamcity "github.com/cvbarros/go-teamcity"
 ```
 
 Construct a new Teamcity client with a default `http.Client` for the server at the `TEAMCITY_ADDR` environment variable, then use the various services exposed by the client to use TeamCity API's features.
@@ -28,7 +28,7 @@ project,  err := client.Projects.GetById("myproject")
 
 ### Examples ###
 
-For now, [integration tests](https://github.com/cvbarros/go-teamcity-sdk/search?q=filename%3A*_test.go&unscoped_q=filename%3A*_test.go) are the best examples on how to use the library to interact with the several services.
+For now, [integration tests](https://github.com/cvbarros/go-teamcity/search?q=filename%3A*_test.go&unscoped_q=filename%3A*_test.go) are the best examples on how to use the library to interact with the several services.
 
 ## Project Status ##
 

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
-module github.com/cvbarros/go-teamcity-sdk
+module github.com/cvbarros/go-teamcity
 
 require (
-	github.com/davecgh/go-spew v1.1.1
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dghubble/sling v1.2.0
-	github.com/google/go-querystring v1.0.0
+	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/motemen/go-loghttp v0.0.0-20170804080138-974ac5ceac27
-	github.com/motemen/go-nuts v0.0.0-20180315145558-42c35bdb11c2
-	github.com/pmezard/go-difflib v1.0.0
+	github.com/motemen/go-nuts v0.0.0-20180315145558-42c35bdb11c2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dghubble/sling v1.2.0 h1:PYGS9ofwbV9nfhB1kYjB1vtXshMxlp2oQxTMMXVJ5pE=
 github.com/dghubble/sling v1.2.0/go.mod h1:ZcPRuLm0qrcULW2gOrjXrAWgf76sahqSyxXyVOvkunE=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/motemen/go-loghttp v0.0.0-20170804080138-974ac5ceac27 h1:uAI3rnOT1OSSY4PUtI/M1orb3q0ewkovwd3wr8xSno4=
 github.com/motemen/go-loghttp v0.0.0-20170804080138-974ac5ceac27/go.mod h1:6eu9CfGt5kfrMVgeu9MfB9PRUnpc47I+udLswiTszI8=
 github.com/motemen/go-nuts v0.0.0-20180315145558-42c35bdb11c2 h1:gfo7RLzXaBdNShd7F5N3K1oM779cD777np9ljUgvf9s=
 github.com/motemen/go-nuts v0.0.0-20180315145558-42c35bdb11c2/go.mod h1:vfh/NPxHgDwggXit20W1llPsXcz39xJ7I8vo7kVrOCk=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/teamcity/agent_requirement_test.go
+++ b/teamcity/agent_requirement_test.go
@@ -3,7 +3,7 @@ package teamcity_test
 import (
 	"testing"
 
-	teamcity "github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/teamcity/artifact_dep_test.go
+++ b/teamcity/artifact_dep_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	teamcity "github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 )
 
 func Test_ArtifactDependency_Invariants(t *testing.T) {

--- a/teamcity/build_feature_test.go
+++ b/teamcity/build_feature_test.go
@@ -3,7 +3,7 @@ package teamcity_test
 import (
 	"testing"
 
-	teamcity "github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/teamcity/build_type_step_test.go
+++ b/teamcity/build_type_step_test.go
@@ -3,7 +3,7 @@ package teamcity_test
 import (
 	"testing"
 
-	"github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/teamcity/build_type_test.go
+++ b/teamcity/build_type_test.go
@@ -3,7 +3,7 @@ package teamcity_test
 import (
 	"testing"
 
-	teamcity "github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/teamcity/context_test.go
+++ b/teamcity/context_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	teamcity "github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 )
 
 type TestContext struct {

--- a/teamcity/dependency_test.go
+++ b/teamcity/dependency_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	teamcity "github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/teamcity/feature_commit_publisher_test.go
+++ b/teamcity/feature_commit_publisher_test.go
@@ -3,7 +3,7 @@ package teamcity_test
 import (
 	"testing"
 
-	"github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/teamcity/parameter_test.go
+++ b/teamcity/parameter_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	teamcity "github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/require"
 )
 

--- a/teamcity/project_test.go
+++ b/teamcity/project_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	teamcity "github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/teamcity/property_assertions_test.go
+++ b/teamcity/property_assertions_test.go
@@ -3,7 +3,7 @@ package teamcity_test
 import (
 	"testing"
 
-	teamcity "github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/teamcity/snapshot_dep_test.go
+++ b/teamcity/snapshot_dep_test.go
@@ -3,7 +3,7 @@ package teamcity_test
 import (
 	"testing"
 
-	teamcity "github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/teamcity/status_publisher_github_options_test.go
+++ b/teamcity/status_publisher_github_options_test.go
@@ -3,7 +3,7 @@ package teamcity_test
 import (
 	"testing"
 
-	"github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/teamcity/teamcity.go
+++ b/teamcity/teamcity.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/dghubble/sling"
 
-	loghttp "github.com/motemen/go-loghttp"
+	"github.com/motemen/go-loghttp"
 	// Enable HTTP log tracing
 	_ "github.com/motemen/go-loghttp/global"
 )

--- a/teamcity/teamcity_test.go
+++ b/teamcity/teamcity_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/teamcity/trigger_test.go
+++ b/teamcity/trigger_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	teamcity "github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/teamcity/trigger_vcs_test.go
+++ b/teamcity/trigger_vcs_test.go
@@ -3,7 +3,7 @@ package teamcity_test
 import (
 	"testing"
 
-	teamcity "github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/teamcity/vcs_root_test.go
+++ b/teamcity/vcs_root_test.go
@@ -3,7 +3,7 @@ package teamcity_test
 import (
 	"testing"
 
-	teamcity "github.com/cvbarros/go-teamcity-sdk/teamcity"
+	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -61,7 +61,7 @@ func TestGitVcsRoot_Update(t *testing.T) {
 	}
 	opt, _ := teamcity.NewGitVcsRootOptionsWithAgentSettings(
 		"refs/head/develop",
-		"https://github.com/cvbarros/go-teamcity-sdk",
+		"https://github.com/cvbarros/go-teamcity",
 		"",
 		teamcity.GitAuthMethodAnonymous,
 		"",
@@ -89,7 +89,7 @@ func TestGitVcsRoot_Update(t *testing.T) {
 
 	actualOpt := actual.Options
 	assert.Equal(teamcity.GitAuthMethodAnonymous, actualOpt.AuthMethod)
-	assert.Equal("https://github.com/cvbarros/go-teamcity-sdk", actualOpt.FetchURL)
+	assert.Equal("https://github.com/cvbarros/go-teamcity", actualOpt.FetchURL)
 	assert.Equal("refs/head/develop", actualOpt.DefaultBranch)
 	assert.Equal("IGNORE", actualOpt.SubModuleCheckout)
 	assert.Equal(teamcity.CleanFilesPolicyIgnoredUntracked, actualOpt.AgentSettings.CleanFilesPolicy)
@@ -100,7 +100,7 @@ func TestGitVcsRoot_Update(t *testing.T) {
 func TestGitVcsRoot_CreateWithUsernamePassword(t *testing.T) {
 	client := setup()
 	newProject := getTestProjectData(testVcsRootProjectId, "")
-	opts, _ := teamcity.NewGitVcsRootOptions("refs/head/master", "https://github.com/cvbarros/go-teamcity-sdk/", "", teamcity.GitAuthMethodPassword, "admin", "admin")
+	opts, _ := teamcity.NewGitVcsRootOptions("refs/head/master", "https://github.com/cvbarros/go-teamcity/", "", teamcity.GitAuthMethodPassword, "admin", "admin")
 
 	createdProject, err := client.Projects.Create(newProject)
 
@@ -135,7 +135,7 @@ func TestGitVcsRoot_CreateWithUsernamePassword(t *testing.T) {
 }
 
 func TestGitVcsRoot_Invariants(t *testing.T) {
-	gitOpt, _ := teamcity.NewGitVcsRootOptionsDefaults("master", "https://github.com/cvbarros/go-teamcity-sdk/")
+	gitOpt, _ := teamcity.NewGitVcsRootOptionsDefaults("master", "https://github.com/cvbarros/go-teamcity/")
 	t.Run("projectID is required", func(t *testing.T) {
 		_, err := teamcity.NewGitVcsRoot("", "name", gitOpt)
 		require.EqualError(t, err, "projectID is required")
@@ -151,7 +151,7 @@ func TestGitVcsRoot_Invariants(t *testing.T) {
 }
 
 func getTestVcsRootData(projectId string) teamcity.VcsRoot {
-	opts, _ := teamcity.NewGitVcsRootOptionsDefaults("refs/head/master", "https://github.com/cvbarros/go-teamcity-sdk")
+	opts, _ := teamcity.NewGitVcsRootOptionsDefaults("refs/head/master", "https://github.com/cvbarros/go-teamcity")
 	v, _ := teamcity.NewGitVcsRoot(projectId, "Application", opts)
 	return v
 }


### PR DESCRIPTION
I'll be renaming the project to `go-teamcity`, which will break usage and imports from `master`.
The reasoning behind this is to keep the project in line with other `go-*` open source libraries, specially the client ones.