### PR TITLE
Added support for TeamCity User Group API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ build: ## Build the project for the current platform
 .PHONY: ci
 ci: test ## Run all the CI targets
 
-.PHONY: test
-test: ## Run the unit tests
+.PHONY: start-docker
+start-docker: ## Starts up docker container running TeamCity Server
 	@test -d  $(TEAMCITY_DATA_DIR) || tar xfz $(INTEGRATION_TEST_DIR)/teamcity_data.tar.gz -C $(INTEGRATION_TEST_DIR)
 	@curl -sL https://download.octopusdeploy.com/octopus-teamcity/4.42.1/Octopus.TeamCity.zip -o $(TEAMCITY_DATA_DIR)/plugins/Octopus.TeamCity.zip
 	@test -n "$$(docker ps -q -f name=$(CONTAINER_NAME))" || docker run --rm -d \
@@ -50,6 +50,9 @@ test: ## Run the unit tests
 		jetbrains/teamcity-server:$(TEAMCITY_VERSION)
 	@echo -n "Teamcity server is booting (this may take a while)..."
 	@until $$(curl -o /dev/null -sfI $(TEAMCITY_HOST)/login.html);do echo -n ".";sleep 5;done
+
+.PHONY: test
+test: start-docker ## Run the unit tests
 	@export TEAMCITY_ADDR=$(TEAMCITY_HOST) \
 		&& GO111MODULE=$(GO111MODULE) go test -v -failfast -timeout 60s ./...
 

--- a/teamcity/group.go
+++ b/teamcity/group.go
@@ -1,0 +1,80 @@
+package teamcity
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/dghubble/sling"
+)
+
+// Group is the model for group entities in TeamCity
+type Group struct {
+	Key         string `json:"key,omitempty" xml:"key"`
+	Description string `json:"description,omitempty" xml:"description"`
+	Name        string `json:"name,omitempty" xml:"name"`
+}
+
+// NewGroup returns an instance of a Group. A non-empty Key and Name is required.
+// Description can be an empty string and will be omitted.
+func NewGroup(key string, name string, description string) (*Group, error) {
+	if key == "" {
+		return nil, fmt.Errorf("Key is required")
+	}
+
+	if name == "" {
+		return nil, fmt.Errorf("Name is required")
+	}
+
+	return &Group{
+		Key:         key,
+		Name:        name,
+		Description: description,
+	}, nil
+}
+
+// GroupService has operations for handling groups
+type GroupService struct {
+	sling      *sling.Sling
+	httpClient *http.Client
+	restHelper *restHelper
+}
+
+func newGroupService(base *sling.Sling, httpClient *http.Client) *GroupService {
+	sling := base.Path("userGroups/")
+	return &GroupService{
+		httpClient: httpClient,
+		sling:      sling,
+		restHelper: newRestHelperWithSling(httpClient, sling),
+	}
+}
+
+// Create - Creates a new group
+func (s *GroupService) Create(group *Group) (*Group, error) {
+	var created Group
+	err := s.restHelper.post("", group, &created, "group")
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &created, nil
+}
+
+// GetByKey - Get a group by its group key
+func (s *GroupService) GetByKey(key string) (*Group, error) {
+	var out Group
+	locator := LocatorKey(key).String()
+	err := s.restHelper.get(locator, &out, "group")
+	if err != nil {
+		return nil, err
+	}
+
+	return &out, err
+}
+
+// Delete - Deletes a group by its group key
+func (s *GroupService) Delete(key string) error {
+	locator := LocatorKey(key).String()
+	err := s.restHelper.delete(locator, "group")
+	return err
+}

--- a/teamcity/group_test.go
+++ b/teamcity/group_test.go
@@ -1,0 +1,63 @@
+package teamcity_test
+
+import (
+	"testing"
+
+	"github.com/cvbarros/go-teamcity/teamcity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGroup_Create(t *testing.T) {
+	newGroup, _ := teamcity.NewGroup("TESTGROUPKEY", "Test Group Name", "Test Group Description")
+	client := setup()
+	actual, err := client.Groups.Create(newGroup)
+
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+	assert.NotEmpty(t, actual.Key)
+
+	cleanUpGroup(t, client, actual.Key)
+
+	assert.Equal(t, newGroup.Key, actual.Key)
+	assert.Equal(t, newGroup.Name, actual.Name)
+	assert.Equal(t, newGroup.Description, actual.Description)
+}
+
+func TestGroup_GetByKey(t *testing.T) {
+	newGroup, _ := teamcity.NewGroup("TESTGROUPKEY", "Test Group Name", "Test Group Description")
+	client := setup()
+	client.Groups.Create(newGroup)
+
+	actual, err := client.Groups.GetByKey(newGroup.Key)
+
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+	assert.NotEmpty(t, actual.Key)
+
+	cleanUpGroup(t, client, actual.Key)
+
+	assert.Equal(t, newGroup.Key, actual.Key)
+	assert.Equal(t, newGroup.Name, actual.Name)
+	assert.Equal(t, newGroup.Description, actual.Description)
+}
+
+func TestGroup_Delete(t *testing.T) {
+	newGroup, _ := teamcity.NewGroup("TESTGROUPKEY", "Test Group Name", "Test Group Description")
+	client := setup()
+	client.Groups.Create(newGroup)
+
+	err := client.Groups.Delete(newGroup.Key)
+
+	require.NoError(t, err)
+
+	_, err = client.Groups.GetByKey(newGroup.Key)
+
+	// Group is deleted, so expect error, and message to contain 404 (NOT FOUND)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func cleanUpGroup(t *testing.T, client *teamcity.Client, key string) {
+	client.Groups.Delete(key)
+}

--- a/teamcity/locator.go
+++ b/teamcity/locator.go
@@ -2,7 +2,7 @@ package teamcity
 
 import "net/url"
 
-//Locator represents a arbitraty locator to be used when querying resources, such as id: or type:
+//Locator represents a arbitraty locator to be used when querying resources, such as id:, type:, or key:
 //These are used in GET requests within the URL so must be properly escaped
 type Locator string
 
@@ -14,6 +14,11 @@ func LocatorID(id string) Locator {
 //LocatorName creates a locator for Project/BuildType by Name
 func LocatorName(name string) Locator {
 	return Locator(url.QueryEscape("name:") + url.PathEscape(name))
+}
+
+//LocatorKey creates a locator for Group by Key
+func LocatorKey(key string) Locator {
+	return Locator(url.QueryEscape("key:") + url.PathEscape(key))
 }
 
 func (l Locator) String() string {

--- a/teamcity/teamcity.go
+++ b/teamcity/teamcity.go
@@ -48,6 +48,7 @@ type Client struct {
 	BuildTypes *BuildTypeService
 	Server     *ServerService
 	VcsRoots   *VcsRootService
+	Groups     *GroupService
 }
 
 // New creates a new client for server address specified at TEAMCITY_ADDR environment variable
@@ -83,6 +84,7 @@ func newClientInstance(userName, password, address string, httpClient *http.Clie
 		BuildTypes: newBuildTypeService(sharedClient.New(), httpClient),
 		Server:     newServerService(sharedClient.New()),
 		VcsRoots:   newVcsRootService(sharedClient.New(), httpClient),
+		Groups:     newGroupService(sharedClient.New(), httpClient),
 	}, nil
 }
 


### PR DESCRIPTION
We have a use case of using terraform to create user groups in TeamCity, and this is related to the PR in `terraform-provider-teamcity`, see [here](https://github.com/cvbarros/terraform-provider-teamcity/pull/69).

Please note that we have not implemented child/parent groups yet, this is just for, create/read/delete of user groups.