### PR TITLE
Updating to use TeamCity 2019.2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.11.1
+      - image: circleci/golang:1.13.9
     environment:
       GO111MODULE: "on"
-      TEAMCITY_VERSION: "2018.1.3"
+      TEAMCITY_VERSION: "2019.2.2"
       CONTAINER_NAME: "teamcity_server"
       INTEGRATION_TEST_DIR: "integration_tests"
       TEAMCITY_DATA_DIR: "integration_tests/data_dir"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ services:
   - docker
 language: go
 go:
- - "1.11.x"
+ - "1.13.x"
 env:
   global:
     - GO111MODULE=on
     - TEAMCITY_ADDR=http://localhost:8112
-    - TEAMCITY_VERSION="2018.1.3"
+    - TEAMCITY_VERSION="2019.2.2"
 
 script:
  - make test

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )
+
+go 1.13

--- a/integration_tests/circleci_start_teamcity.sh
+++ b/integration_tests/circleci_start_teamcity.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eo pipefail
-#Grab DOCKER_HOST fro CircleCI
+#Grab DOCKER_HOST from CircleCI
 TEAMCITY_HOST=$DOCKER_HOST:8112
 
 docker create -v /data/teamcity_server/datadir --name data alpine:3.4 /bin/true

--- a/teamcity/server_test.go
+++ b/teamcity/server_test.go
@@ -17,6 +17,6 @@ func TestServer_Get(t *testing.T) {
 		t.Fatalf("GetServer did not return a server or serialization failure.")
 	}
 
-	assert.Equal(t, int32(2018), server.VersionMajor)
+	assert.Equal(t, int32(2019), server.VersionMajor)
 	assert.NotEmpty(t, server.WebURL)
 }


### PR DESCRIPTION
👋 

In this PR I've extracted the `teamcity_data.tar.gz`, run an upgrade and re-captured the data directory. I've also updated to use Go 1.13, since that's what other Terraform Providers are using - and patched the Circle CI and Travis CI builds at the same time

Fixes #69 - hope you don't mind @cvbarros

Tests pass:

```
$ TEAMCITY_ADDR="http://localhost:8112" go test -v -failfast -timeout 180s ./...
=== RUN   Test_ArtifactDependencyOptions_Invariants
=== RUN   Test_ArtifactDependencyOptions_Invariants/pathRules_is_required
=== RUN   Test_ArtifactDependencyOptions_Invariants/revisionType_is_required
=== RUN   Test_ArtifactDependencyOptions_Invariants/revisionValue_is_required_is_using_'BuildWithSpecifiedNumber'
=== RUN   Test_ArtifactDependencyOptions_Invariants/revisionValue_is_required_is_using_'LastBuildFinishedWithTag'
--- PASS: Test_ArtifactDependencyOptions_Invariants (0.00s)
    --- PASS: Test_ArtifactDependencyOptions_Invariants/pathRules_is_required (0.00s)
    --- PASS: Test_ArtifactDependencyOptions_Invariants/revisionType_is_required (0.00s)
    --- PASS: Test_ArtifactDependencyOptions_Invariants/revisionValue_is_required_is_using_'BuildWithSpecifiedNumber' (0.00s)
    --- PASS: Test_ArtifactDependencyOptions_Invariants/revisionValue_is_required_is_using_'LastBuildFinishedWithTag' (0.00s)
=== RUN   Test_ArtifactDependencyOptions_ConstructorDefault
--- PASS: Test_ArtifactDependencyOptions_ConstructorDefault (0.00s)
=== RUN   Test_ArtifactDependencyOptions_ConstructorLatestPinned
--- PASS: Test_ArtifactDependencyOptions_ConstructorLatestPinned (0.00s)
=== RUN   Test_ArtifactDependencyOptions_ConstructorLatestFinished
--- PASS: Test_ArtifactDependencyOptions_ConstructorLatestFinished (0.00s)
=== RUN   Test_ArtifactDependencyOptions_ConstructorSameChain
--- PASS: Test_ArtifactDependencyOptions_ConstructorSameChain (0.00s)
=== RUN   Test_ArtifactDependencyOptions_ConstructorSpecificBuildNumber
--- PASS: Test_ArtifactDependencyOptions_ConstructorSpecificBuildNumber (0.00s)
=== RUN   Test_ArtifactDependencyOptions_ConstructorLastFinishedWithTag
--- PASS: Test_ArtifactDependencyOptions_ConstructorLastFinishedWithTag (0.00s)
=== RUN   Test_ArtifactDependencyOptions_BuildTagStrip
--- PASS: Test_ArtifactDependencyOptions_BuildTagStrip (0.00s)
=== RUN   Test_PropertiesArtifactRules_EmitEvenWhenEmpty
--- PASS: Test_PropertiesArtifactRules_EmitEvenWhenEmpty (0.00s)
=== RUN   Test_PropertiesAllowTriggeringPersonalBuilds_OmitWhenTrue
--- PASS: Test_PropertiesAllowTriggeringPersonalBuilds_OmitWhenTrue (0.00s)
=== RUN   Test_ConvertFromPropertiesAllowTriggringPersonalBuilds_SetsDefaultTrue
--- PASS: Test_ConvertFromPropertiesAllowTriggringPersonalBuilds_SetsDefaultTrue (0.00s)
=== RUN   Test_PropertiesBuildConfigurationType_OmitWhenDefault
--- PASS: Test_PropertiesBuildConfigurationType_OmitWhenDefault (0.00s)
=== RUN   Test_ConvertFromPropertiesBuildConfigurationType_SetsDefault
--- PASS: Test_ConvertFromPropertiesBuildConfigurationType_SetsDefault (0.00s)
=== RUN   Test_PropertiesBuildNumberFormat_OmitWhenDefault
--- PASS: Test_PropertiesBuildNumberFormat_OmitWhenDefault (0.00s)
=== RUN   Test_ConvertFromPropertiesBuildNumberFormat_SetsDefault
--- PASS: Test_ConvertFromPropertiesBuildNumberFormat_SetsDefault (0.00s)
=== RUN   Test_PropertiesEnableStatusWidget_OmitWhenFalse
--- PASS: Test_PropertiesEnableStatusWidget_OmitWhenFalse (0.00s)
=== RUN   Test_ConvertFromPropertiesEnableStatusWidget_SetsDefault
--- PASS: Test_ConvertFromPropertiesEnableStatusWidget_SetsDefault (0.00s)
=== RUN   Test_PropertiesEnableHangingBuildsDetection_OmitWhenTrue
--- PASS: Test_PropertiesEnableHangingBuildsDetection_OmitWhenTrue (0.00s)
=== RUN   Test_ConvertFromPropertiesEnableHangingBuildsDetection_SetsDefault
--- PASS: Test_ConvertFromPropertiesEnableHangingBuildsDetection_SetsDefault (0.00s)
=== RUN   Test_PropertiesMaxSimultaneousBuilds_OmitWhenZero
--- PASS: Test_PropertiesMaxSimultaneousBuilds_OmitWhenZero (0.00s)
=== RUN   Test_ConvertFromPropertiesMaxSimultaneousBuilds_SetsDefault
--- PASS: Test_ConvertFromPropertiesMaxSimultaneousBuilds_SetsDefault (0.00s)
=== RUN   Test_PropertiesIfTemplate_OmitBuildCounter
--- PASS: Test_PropertiesIfTemplate_OmitBuildCounter (0.00s)
=== RUN   Test_Properties_Full
--- PASS: Test_Properties_Full (0.00s)
=== RUN   Test_GitVcsRootOptionsConstructor
=== RUN   Test_GitVcsRootOptionsConstructor/Properties_initialized_correctly
=== RUN   Test_GitVcsRootOptionsConstructor/PushURL_should_use_FetchURL_if_empty
=== RUN   Test_GitVcsRootOptionsConstructor/authMethod_is_required
=== RUN   Test_GitVcsRootOptionsConstructor/defaultBranch_is_required
=== RUN   Test_GitVcsRootOptionsConstructor/fetchURL_is_required
--- PASS: Test_GitVcsRootOptionsConstructor (0.00s)
    --- PASS: Test_GitVcsRootOptionsConstructor/Properties_initialized_correctly (0.00s)
    --- PASS: Test_GitVcsRootOptionsConstructor/PushURL_should_use_FetchURL_if_empty (0.00s)
    --- PASS: Test_GitVcsRootOptionsConstructor/authMethod_is_required (0.00s)
    --- PASS: Test_GitVcsRootOptionsConstructor/defaultBranch_is_required (0.00s)
    --- PASS: Test_GitVcsRootOptionsConstructor/fetchURL_is_required (0.00s)
=== RUN   Test_GitVcsRootOptionsVcsRootProperties_AnonymousAuth
--- PASS: Test_GitVcsRootOptionsVcsRootProperties_AnonymousAuth (0.00s)
=== RUN   Test_GitVcsRootOptionsVcsRootProperties_UsernamePasswordAuth
--- PASS: Test_GitVcsRootOptionsVcsRootProperties_UsernamePasswordAuth (0.00s)
=== RUN   Test_GitVcsRootOptionsVcsRootProperties_UsernamePasswordAuth_UsernameRequired
--- PASS: Test_GitVcsRootOptionsVcsRootProperties_UsernamePasswordAuth_UsernameRequired (0.00s)
=== RUN   Test_GitVcsRootOptionsVcsRootProperties_UploadedKeyAuth
--- PASS: Test_GitVcsRootOptionsVcsRootProperties_UploadedKeyAuth (0.00s)
=== RUN   Test_GitVcsRootOptionsVcsRootProperties_CustomKeyAuth
--- PASS: Test_GitVcsRootOptionsVcsRootProperties_CustomKeyAuth (0.00s)
=== RUN   Test_GitVcsRootOptionsVcsRootProperties_BranchSpec
--- PASS: Test_GitVcsRootOptionsVcsRootProperties_BranchSpec (0.00s)
=== RUN   Test_GitVcsRootOptionsVcsRootProperties_EnableTagsInBranchSpec
--- PASS: Test_GitVcsRootOptionsVcsRootProperties_EnableTagsInBranchSpec (0.00s)
=== RUN   Test_GitVcsRootOptionsVcsRootProperties_DefaultAgentSettings
--- PASS: Test_GitVcsRootOptionsVcsRootProperties_DefaultAgentSettings (0.00s)
=== RUN   Test_PropertiesToGitVcsRootOptions
--- PASS: Test_PropertiesToGitVcsRootOptions (0.00s)
=== RUN   Test_LocatorNameWithSpaces
--- PASS: Test_LocatorNameWithSpaces (0.00s)
=== RUN   Test_LocatorId
--- PASS: Test_LocatorId (0.00s)
=== RUN   Test_FinishTriggerOptionsConstructor
--- PASS: Test_FinishTriggerOptionsConstructor (0.00s)
=== RUN   Test_FinishTriggerOptionsConvertToProperties
--- PASS: Test_FinishTriggerOptionsConvertToProperties (0.00s)
=== RUN   Test_ForceFalsePropertiesIfApplicable
--- PASS: Test_ForceFalsePropertiesIfApplicable (0.00s)
=== RUN   Test_TriggerScheduleDeserializeDaily
--- PASS: Test_TriggerScheduleDeserializeDaily (0.00s)
=== RUN   Test_TriggerScheduleDeserializeWeekly
--- PASS: Test_TriggerScheduleDeserializeWeekly (0.00s)
=== RUN   Test_TriggerScheduleSerializeDaily
--- PASS: Test_TriggerScheduleSerializeDaily (0.00s)
=== RUN   Test_TriggerScheduleSerializeWeekly
--- PASS: Test_TriggerScheduleSerializeWeekly (0.00s)
=== RUN   Test_TriggerDeserializeScheduleOptions
--- PASS: Test_TriggerDeserializeScheduleOptions (0.00s)
=== RUN   Test_TriggerVcsOptionsDefaults
--- PASS: Test_TriggerVcsOptionsDefaults (0.00s)
=== RUN   Test_TriggerVcsOptionsQuietPeriodModeCustom
--- PASS: Test_TriggerVcsOptionsQuietPeriodModeCustom (0.00s)
=== RUN   Test_TriggerVcsOptionsQuietPeriodModeNotCustom
--- PASS: Test_TriggerVcsOptionsQuietPeriodModeNotCustom (0.00s)
=== RUN   Test_TriggerVcsOptions_EnableQueueOptimizationDisablesPerCheckinTriggering
--- PASS: Test_TriggerVcsOptions_EnableQueueOptimizationDisablesPerCheckinTriggering (0.00s)
=== RUN   Test_TriggerVcsOptions_EnablePerCheckinTriggeringDisablesQueueOptimization
--- PASS: Test_TriggerVcsOptions_EnablePerCheckinTriggeringDisablesQueueOptimization (0.00s)
=== RUN   TestAgentRequirement_Create
--- PASS: TestAgentRequirement_Create (0.19s)
=== RUN   TestAgentRequirement_Get
--- PASS: TestAgentRequirement_Get (0.14s)
=== RUN   TestAgentRequirement_GetAll
--- PASS: TestAgentRequirement_GetAll (0.19s)
=== RUN   TestAgentRequirement_Delete
--- PASS: TestAgentRequirement_Delete (0.22s)
=== RUN   Test_ArtifactDependency_Invariants
=== RUN   Test_ArtifactDependency_Invariants/sourceBuildID_is_required
=== RUN   Test_ArtifactDependency_Invariants/opt_must_be_non-nil_and_valid
--- PASS: Test_ArtifactDependency_Invariants (0.00s)
    --- PASS: Test_ArtifactDependency_Invariants/sourceBuildID_is_required (0.00s)
    --- PASS: Test_ArtifactDependency_Invariants/opt_must_be_non-nil_and_valid (0.00s)
=== RUN   Test_ArtifactDependency_Constructor
--- PASS: Test_ArtifactDependency_Constructor (0.00s)
=== RUN   TestBuildFeatureSuite
=== RUN   TestBuildFeatureSuite/TestCommitPublisher_Create
=== RUN   TestBuildFeatureSuite/TestCommitPublisher_Get
--- PASS: TestBuildFeatureSuite (0.31s)
    --- PASS: TestBuildFeatureSuite/TestCommitPublisher_Create (0.12s)
    --- PASS: TestBuildFeatureSuite/TestCommitPublisher_Get (0.19s)
=== RUN   Test_AttachBuildTemplate
--- PASS: Test_AttachBuildTemplate (0.21s)
=== RUN   Test_DetachBuildTemplate
--- PASS: Test_DetachBuildTemplate (0.31s)
=== RUN   TestBuildTypeStepsSuite
=== RUN   TestBuildTypeStepsSuite/TestAdd_Inline
=== RUN   TestBuildTypeStepsSuite/TestAdd_StepCmdLineExecutable
=== RUN   TestBuildTypeStepsSuite/TestAdd_StepCmdLineScript
=== RUN   TestBuildTypeStepsSuite/TestAdd_StepOctopusCreateRelease
=== RUN   TestBuildTypeStepsSuite/TestAdd_StepOctopusPushPackage
=== RUN   TestBuildTypeStepsSuite/TestAdd_StepPowershell
=== RUN   TestBuildTypeStepsSuite/TestDelete
=== RUN   TestBuildTypeStepsSuite/TestGet_All
=== RUN   TestBuildTypeStepsSuite/TestGet_Inline
--- PASS: TestBuildTypeStepsSuite (1.71s)
    --- PASS: TestBuildTypeStepsSuite/TestAdd_Inline (0.22s)
    --- PASS: TestBuildTypeStepsSuite/TestAdd_StepCmdLineExecutable (0.15s)
    --- PASS: TestBuildTypeStepsSuite/TestAdd_StepCmdLineScript (0.20s)
    --- PASS: TestBuildTypeStepsSuite/TestAdd_StepOctopusCreateRelease (0.20s)
    --- PASS: TestBuildTypeStepsSuite/TestAdd_StepOctopusPushPackage (0.16s)
    --- PASS: TestBuildTypeStepsSuite/TestAdd_StepPowershell (0.15s)
    --- PASS: TestBuildTypeStepsSuite/TestDelete (0.17s)
    --- PASS: TestBuildTypeStepsSuite/TestGet_All (0.23s)
    --- PASS: TestBuildTypeStepsSuite/TestGet_Inline (0.22s)
=== RUN   TestBuildType_Create
--- PASS: TestBuildType_Create (0.12s)
=== RUN   TestBuildType_CreateWithChildProject
--- PASS: TestBuildType_CreateWithChildProject (0.26s)
=== RUN   TestBuildTypeTemplate_Create
--- PASS: TestBuildTypeTemplate_Create (0.15s)
=== RUN   TestBuildType_Get
--- PASS: TestBuildType_Get (0.14s)
=== RUN   TestBuildType_Update
--- PASS: TestBuildType_Update (0.23s)
=== RUN   TestBuildType_CreateWithParameters
--- PASS: TestBuildType_CreateWithParameters (0.11s)
=== RUN   TestBuildType_UpdateParameters
--- PASS: TestBuildType_UpdateParameters (0.28s)
=== RUN   TestBuildType_UpdateParametersWithRemoval
--- PASS: TestBuildType_UpdateParametersWithRemoval (0.37s)
=== RUN   TestBuildType_GetParametersExcludeInherited
--- PASS: TestBuildType_GetParametersExcludeInherited (0.24s)
=== RUN   TestBuildType_AttachVcsRoot
--- PASS: TestBuildType_AttachVcsRoot (0.15s)
=== RUN   TestSnapshotDependency_Create
--- PASS: TestSnapshotDependency_Create (0.22s)
=== RUN   TestSnapshotDependency_Get
--- PASS: TestSnapshotDependency_Get (0.17s)
=== RUN   TestSnapshotDependency_Delete
--- PASS: TestSnapshotDependency_Delete (0.16s)
=== RUN   TestArtifactDependency_Create
--- PASS: TestArtifactDependency_Create (0.37s)
=== RUN   TestArtifactDependency_Get
--- PASS: TestArtifactDependency_Get (0.24s)
=== RUN   TestArtifactDependency_Delete
--- PASS: TestArtifactDependency_Delete (0.32s)
=== RUN   TestFeatureCommitPublisher_UnmarshallProperties_Github
--- PASS: TestFeatureCommitPublisher_UnmarshallProperties_Github (0.00s)
=== RUN   Test_ParameterConfiguration_Serialization
--- PASS: Test_ParameterConfiguration_Serialization (0.00s)
=== RUN   Test_ParameterSystem_Serialization
--- PASS: Test_ParameterSystem_Serialization (0.00s)
=== RUN   Test_ParameterEnvironmentVariable_Serialization
--- PASS: Test_ParameterEnvironmentVariable_Serialization (0.00s)
=== RUN   Test_ParameterCollection_Serialization
--- PASS: Test_ParameterCollection_Serialization (0.00s)
=== RUN   Test_ParameterConvertToProperty
--- PASS: Test_ParameterConvertToProperty (0.00s)
=== RUN   TestProject_Create
--- PASS: TestProject_Create (0.12s)
=== RUN   TestProject_CreateWithParent
--- PASS: TestProject_CreateWithParent (0.15s)
=== RUN   TestProject_UpdateWithSameParentDoesNotChangeName
--- PASS: TestProject_UpdateWithSameParentDoesNotChangeName (0.20s)
=== RUN   TestProject_UpdateParent
--- PASS: TestProject_UpdateParent (0.37s)
=== RUN   TestProject_UpdateParameters
--- PASS: TestProject_UpdateParameters (0.40s)
=== RUN   TestProject_UpdateParametersWithRemoval
--- PASS: TestProject_UpdateParametersWithRemoval (0.27s)
=== RUN   TestProject_GetByName
--- PASS: TestProject_GetByName (0.16s)
=== RUN   TestProject_GetRootByName
--- PASS: TestProject_GetRootByName (0.01s)
=== RUN   TestProject_BuildTypes
--- PASS: TestProject_BuildTypes (0.21s)
=== RUN   TestProject_ValidateName
--- PASS: TestProject_ValidateName (0.00s)
=== RUN   TestProject_GetUnauthorizedHandled
--- PASS: TestProject_GetUnauthorizedHandled (0.06s)
=== RUN   TestServer_Get
--- PASS: TestServer_Get (0.01s)
=== RUN   TestSnapshotDependency_Constructor
--- PASS: TestSnapshotDependency_Constructor (0.00s)
=== RUN   TestSnapshotDependency_ConstructorWithOptions
--- PASS: TestSnapshotDependency_ConstructorWithOptions (0.00s)
=== RUN   TestFeatureCommitPublisher_Invariants
=== RUN   TestFeatureCommitPublisher_Invariants/AuthenticationType_Required
=== RUN   TestFeatureCommitPublisher_Invariants/AuthenticationType_Valid
=== RUN   TestFeatureCommitPublisher_Invariants/Host_Required
--- PASS: TestFeatureCommitPublisher_Invariants (0.00s)
    --- PASS: TestFeatureCommitPublisher_Invariants/AuthenticationType_Required (0.00s)
    --- PASS: TestFeatureCommitPublisher_Invariants/AuthenticationType_Valid (0.00s)
    --- PASS: TestFeatureCommitPublisher_Invariants/Host_Required (0.00s)
=== RUN   TestFeatureCommitPublisher_GithubAuthenticationPassword
=== RUN   TestFeatureCommitPublisher_GithubAuthenticationPassword/Username_Required
=== RUN   TestFeatureCommitPublisher_GithubAuthenticationPassword/Password_Required
=== RUN   TestFeatureCommitPublisher_GithubAuthenticationPassword/Correct_Properties
--- PASS: TestFeatureCommitPublisher_GithubAuthenticationPassword (0.00s)
    --- PASS: TestFeatureCommitPublisher_GithubAuthenticationPassword/Username_Required (0.00s)
    --- PASS: TestFeatureCommitPublisher_GithubAuthenticationPassword/Password_Required (0.00s)
    --- PASS: TestFeatureCommitPublisher_GithubAuthenticationPassword/Correct_Properties (0.00s)
=== RUN   TestFeatureCommitPublisher_GithubAuthenticationToken
=== RUN   TestFeatureCommitPublisher_GithubAuthenticationToken/AccessToken_Required
=== RUN   TestFeatureCommitPublisher_GithubAuthenticationToken/Correct_Properties
--- PASS: TestFeatureCommitPublisher_GithubAuthenticationToken (0.00s)
    --- PASS: TestFeatureCommitPublisher_GithubAuthenticationToken/AccessToken_Required (0.00s)
    --- PASS: TestFeatureCommitPublisher_GithubAuthenticationToken/Correct_Properties (0.00s)
=== RUN   TestFeatureCommitPublisher_GithubFromProperties
=== RUN   TestFeatureCommitPublisher_GithubFromProperties/From_Password_AuthType
=== RUN   TestFeatureCommitPublisher_GithubFromProperties/From_Token_AuthType
--- PASS: TestFeatureCommitPublisher_GithubFromProperties (0.00s)
    --- PASS: TestFeatureCommitPublisher_GithubFromProperties/From_Password_AuthType (0.00s)
    --- PASS: TestFeatureCommitPublisher_GithubFromProperties/From_Token_AuthType (0.00s)
=== RUN   TestSerialize
--- PASS: TestSerialize (0.00s)
=== RUN   TestClient_BasicAuth
=== RUN   TestClient_BasicAuth/Basic_auth_works_against_local_instance
--- PASS: TestClient_BasicAuth (0.02s)
    --- PASS: TestClient_BasicAuth/Basic_auth_works_against_local_instance (0.02s)
=== RUN   TestClient_Address
=== RUN   TestClient_Address/Specify_address_from_alternate_constructor
--- PASS: TestClient_Address (0.02s)
    --- PASS: TestClient_Address/Specify_address_from_alternate_constructor (0.02s)
=== RUN   TestSuiteBuildTypeTrigger
=== RUN   TestSuiteBuildTypeTrigger/TestBuildFinishTrigger_Create
=== RUN   TestSuiteBuildTypeTrigger/TestBuildFinishTrigger_Delete
=== RUN   TestSuiteBuildTypeTrigger/TestBuildFinishTrigger_Get
=== RUN   TestSuiteBuildTypeTrigger/TestScheduledDailyTrigger_Create
=== RUN   TestSuiteBuildTypeTrigger/TestScheduledDailyTrigger_Delete
=== RUN   TestSuiteBuildTypeTrigger/TestScheduledDailyTrigger_Get
=== RUN   TestSuiteBuildTypeTrigger/TestScheduledWeeklyTrigger_Create
=== RUN   TestSuiteBuildTypeTrigger/TestScheduledWeeklyTrigger_Delete
=== RUN   TestSuiteBuildTypeTrigger/TestScheduledWeeklyTrigger_Get
=== RUN   TestSuiteBuildTypeTrigger/TestVcsTrigger_Create
=== RUN   TestSuiteBuildTypeTrigger/TestVcsTrigger_CreateTwoHandledGracefully
=== RUN   TestSuiteBuildTypeTrigger/TestVcsTrigger_Delete
=== RUN   TestSuiteBuildTypeTrigger/TestVcsTrigger_Get
--- PASS: TestSuiteBuildTypeTrigger (4.45s)
    --- PASS: TestSuiteBuildTypeTrigger/TestBuildFinishTrigger_Create (0.21s)
    --- PASS: TestSuiteBuildTypeTrigger/TestBuildFinishTrigger_Delete (0.42s)
    --- PASS: TestSuiteBuildTypeTrigger/TestBuildFinishTrigger_Get (0.39s)
    --- PASS: TestSuiteBuildTypeTrigger/TestScheduledDailyTrigger_Create (0.24s)
    --- PASS: TestSuiteBuildTypeTrigger/TestScheduledDailyTrigger_Delete (0.54s)
    --- PASS: TestSuiteBuildTypeTrigger/TestScheduledDailyTrigger_Get (0.30s)
    --- PASS: TestSuiteBuildTypeTrigger/TestScheduledWeeklyTrigger_Create (0.34s)
    --- PASS: TestSuiteBuildTypeTrigger/TestScheduledWeeklyTrigger_Delete (0.44s)
    --- PASS: TestSuiteBuildTypeTrigger/TestScheduledWeeklyTrigger_Get (0.27s)
    --- PASS: TestSuiteBuildTypeTrigger/TestVcsTrigger_Create (0.29s)
    --- PASS: TestSuiteBuildTypeTrigger/TestVcsTrigger_CreateTwoHandledGracefully (0.38s)
    --- PASS: TestSuiteBuildTypeTrigger/TestVcsTrigger_Delete (0.40s)
    --- PASS: TestSuiteBuildTypeTrigger/TestVcsTrigger_Get (0.25s)
=== RUN   TestTrigger_Constructor
--- PASS: TestTrigger_Constructor (0.00s)
=== RUN   TestGitVcsRoot_Get
--- PASS: TestGitVcsRoot_Get (0.14s)
=== RUN   TestGitVcsRoot_Update
--- PASS: TestGitVcsRoot_Update (0.50s)
=== RUN   TestGitVcsRoot_CreateWithUsernamePassword
--- PASS: TestGitVcsRoot_CreateWithUsernamePassword (0.14s)
=== RUN   TestGitVcsRoot_Invariants
=== RUN   TestGitVcsRoot_Invariants/projectID_is_required
=== RUN   TestGitVcsRoot_Invariants/name_is_required
=== RUN   TestGitVcsRoot_Invariants/opts_is_required
--- PASS: TestGitVcsRoot_Invariants (0.00s)
    --- PASS: TestGitVcsRoot_Invariants/projectID_is_required (0.00s)
    --- PASS: TestGitVcsRoot_Invariants/name_is_required (0.00s)
    --- PASS: TestGitVcsRoot_Invariants/opts_is_required (0.00s)
PASS
ok  	github.com/cvbarros/go-teamcity/teamcity	14.066s
```