### PR TITLE
Support for managing Agent Pools & assigning/unassigning projects

### DIFF
--- a/teamcity/agent_pool.go
+++ b/teamcity/agent_pool.go
@@ -99,7 +99,7 @@ func (s *AgentPoolsService) Delete(id int) error {
 }
 
 // Get will return an Agent Pool based on it's ID
-func (s *AgentPoolsService) Get(id int) (*AgentPool, error) {
+func (s *AgentPoolsService) GetByID(id int) (*AgentPool, error) {
 	var out AgentPool
 	locator := LocatorIDInt(id).String()
 	err := s.restHelper.get(locator, &out, "Agent Pool")

--- a/teamcity/agent_pool.go
+++ b/teamcity/agent_pool.go
@@ -133,6 +133,19 @@ func (s *AgentPoolsService) List() (*ListAgentPools, error) {
 	return &out, nil
 }
 
+// List returns all of the assigned Agent Pools for a specific Project
+func (s *AgentPoolsService) ListForProject(projectId string) (*ListAgentPools, error) {
+	var out ListAgentPools
+
+	locator := LocatorID(projectId) // /app/rest/agentPools/?locator=project:(id:_Root)
+	err := s.restHelper.get(fmt.Sprintf("?locator=project:(%s)", locator), &out, "Agent Pools")
+	if err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
 // UnassignProject unassigns a Project from a Agent Pool
 func (s *AgentPoolsService) UnassignProject(poolId int, projectId string) error {
 	poolLocator := LocatorIDInt(poolId).String()

--- a/teamcity/agent_pool.go
+++ b/teamcity/agent_pool.go
@@ -1,0 +1,47 @@
+package teamcity
+
+import (
+	"net/http"
+
+	"github.com/dghubble/sling"
+)
+
+// ListAgentPools is the response object when listing Agent Pools
+type ListAgentPools struct {
+	Count      int                  `json:"count,omitempty" xml:"count"`
+	Href       string               `json:"href,omitempty" xml:"href"`
+	AgentPools []AgentPoolReference `json:"agentPool,omitempty" xml:"agentPool"`
+}
+
+// AgentPoolReference is a reference to an Agent Pool
+type AgentPoolReference struct {
+	Href string `json:"href,omitempty" xml:"href"`
+	Id   string `json:"id,omitempty" xml:"id"`
+	Name string `json:"name,omitempty" xml:"name"`
+}
+
+// AgentPoolsService has operations for handling agent pools
+type AgentPoolsService struct {
+	sling      *sling.Sling
+	httpClient *http.Client
+	restHelper *restHelper
+}
+
+func newAgentPoolsService(base *sling.Sling, client *http.Client) *AgentPoolsService {
+	sling := base.Path("agentPools/")
+	return &AgentPoolsService{
+		sling:      sling,
+		httpClient: client,
+		restHelper: newRestHelperWithSling(client, sling),
+	}
+}
+
+func (s *AgentPoolsService) List() (*ListAgentPools, error) {
+	var out ListAgentPools
+	err := s.restHelper.get("", &out, "Agent Pools")
+	if err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}

--- a/teamcity/agent_pool.go
+++ b/teamcity/agent_pool.go
@@ -110,6 +110,18 @@ func (s *AgentPoolsService) GetByID(id int) (*AgentPool, error) {
 	return &out, nil
 }
 
+// Get will return an Agent Pool based on it's Name
+func (s *AgentPoolsService) GetByName(name string) (*AgentPool, error) {
+	var out AgentPool
+	locator := LocatorName(name).String()
+	err := s.restHelper.get(locator, &out, "Agent Pool")
+	if err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
 // List returns all of the available Agent Pools
 func (s *AgentPoolsService) List() (*ListAgentPools, error) {
 	var out ListAgentPools

--- a/teamcity/agent_pool.go
+++ b/teamcity/agent_pool.go
@@ -20,6 +20,7 @@ type AgentPoolReference struct {
 	Name string `json:"name,omitempty" xml:"name"`
 }
 
+// AgentPool contains information about the Agent Pool
 type AgentPool struct {
 	Href      string `json:"href,omitempty" xml:"href"`
 	Id        int    `json:"id,omitempty" xml:"id"`
@@ -43,6 +44,7 @@ func newAgentPoolsService(base *sling.Sling, client *http.Client) *AgentPoolsSer
 	}
 }
 
+// Create will create an Agent Pool - which must have a unique name
 func (s *AgentPoolsService) Create(pool AgentPool) (*AgentPool, error) {
 	var created AgentPool
 
@@ -54,6 +56,7 @@ func (s *AgentPoolsService) Create(pool AgentPool) (*AgentPool, error) {
 	return &created, nil
 }
 
+// Delete will delete an Agent Pool based on it's ID
 func (s *AgentPoolsService) Delete(id int) error {
 	locator := LocatorIDInt(id).String()
 	err := s.restHelper.delete(locator, "Agent Pool")
@@ -64,6 +67,7 @@ func (s *AgentPoolsService) Delete(id int) error {
 	return nil
 }
 
+// Get will return an Agent Pool based on it's ID
 func (s *AgentPoolsService) Get(id int) (*AgentPool, error) {
 	var out AgentPool
 	locator := LocatorIDInt(id).String()
@@ -75,6 +79,7 @@ func (s *AgentPoolsService) Get(id int) (*AgentPool, error) {
 	return &out, nil
 }
 
+// List returns all of the available Agent Pools
 func (s *AgentPoolsService) List() (*ListAgentPools, error) {
 	var out ListAgentPools
 	err := s.restHelper.get("", &out, "Agent Pools")
@@ -84,3 +89,7 @@ func (s *AgentPoolsService) List() (*ListAgentPools, error) {
 
 	return &out, nil
 }
+
+// NOTE: Update support was investigated but is intentionally omitted - as the TC Documentation is incorrect
+//		 PUT /app/rest/agentPools/id:4 at the time of writing returns a 405 Method Not Allowed
+//		 POST /app/rest/agentPools with href & ID set also creates a new node pool

--- a/teamcity/agent_pool.go
+++ b/teamcity/agent_pool.go
@@ -22,10 +22,22 @@ type AgentPoolReference struct {
 
 // AgentPool contains information about the Agent Pool
 type AgentPool struct {
-	Href      string `json:"href,omitempty" xml:"href"`
-	Id        int    `json:"id,omitempty" xml:"id"`
+	Href      string                       `json:"href,omitempty" xml:"href"`
+	Id        int                          `json:"id,omitempty" xml:"id"`
+	Name      string                       `json:"name,omitempty" xml:"name"`
+	MaxAgents *int                         `json:"maxAgents,omitempty" xml:"maxAgents"`
+	Projects  *AgentPoolProjectAssignments `json:"projects,omitempty" xml:"projects"`
+}
+
+// CreateAgentPool contains information needed to create an Agent Pool
+type CreateAgentPool struct {
 	Name      string `json:"name,omitempty" xml:"name"`
 	MaxAgents *int   `json:"maxAgents,omitempty" xml:"maxAgents"`
+}
+
+// AgentPoolProjectAssignments is a wrapper containing the Projects attached to this Agent Pool
+type AgentPoolProjectAssignments struct {
+	Project []ProjectReference `json:"project,omitempty" xml:"project"`
 }
 
 // AgentPoolsService has operations for handling agent pools
@@ -45,7 +57,7 @@ func newAgentPoolsService(base *sling.Sling, client *http.Client) *AgentPoolsSer
 }
 
 // Create will create an Agent Pool - which must have a unique name
-func (s *AgentPoolsService) Create(pool AgentPool) (*AgentPool, error) {
+func (s *AgentPoolsService) Create(pool CreateAgentPool) (*AgentPool, error) {
 	var created AgentPool
 
 	err := s.restHelper.post("", pool, &created, "Agent Pool")

--- a/teamcity/agent_pool.go
+++ b/teamcity/agent_pool.go
@@ -16,8 +16,15 @@ type ListAgentPools struct {
 // AgentPoolReference is a reference to an Agent Pool
 type AgentPoolReference struct {
 	Href string `json:"href,omitempty" xml:"href"`
-	Id   string `json:"id,omitempty" xml:"id"`
+	Id   int    `json:"id,omitempty" xml:"id"`
 	Name string `json:"name,omitempty" xml:"name"`
+}
+
+type AgentPool struct {
+	Href      string `json:"href,omitempty" xml:"href"`
+	Id        int    `json:"id,omitempty" xml:"id"`
+	Name      string `json:"name,omitempty" xml:"name"`
+	MaxAgents *int   `json:"maxAgents,omitempty" xml:"maxAgents"`
 }
 
 // AgentPoolsService has operations for handling agent pools
@@ -34,6 +41,38 @@ func newAgentPoolsService(base *sling.Sling, client *http.Client) *AgentPoolsSer
 		httpClient: client,
 		restHelper: newRestHelperWithSling(client, sling),
 	}
+}
+
+func (s *AgentPoolsService) Create(pool AgentPool) (*AgentPool, error) {
+	var created AgentPool
+
+	err := s.restHelper.post("", pool, &created, "Agent Pool")
+	if err != nil {
+		return nil, err
+	}
+
+	return &created, nil
+}
+
+func (s *AgentPoolsService) Delete(id int) error {
+	locator := LocatorIDInt(id).String()
+	err := s.restHelper.delete(locator, "Agent Pool")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *AgentPoolsService) Get(id int) (*AgentPool, error) {
+	var out AgentPool
+	locator := LocatorIDInt(id).String()
+	err := s.restHelper.get(locator, &out, "Agent Pool")
+	if err != nil {
+		return nil, err
+	}
+
+	return &out, nil
 }
 
 func (s *AgentPoolsService) List() (*ListAgentPools, error) {

--- a/teamcity/agent_pool.go
+++ b/teamcity/agent_pool.go
@@ -1,6 +1,7 @@
 package teamcity
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/dghubble/sling"
@@ -56,6 +57,24 @@ func newAgentPoolsService(base *sling.Sling, client *http.Client) *AgentPoolsSer
 	}
 }
 
+// AssignProject assigns a Project to a Agent Pool
+func (s *AgentPoolsService) AssignProject(poolId int, projectId string) error {
+	var project struct {
+		ID string `json:"id" xml:"id"`
+	}
+	project.ID = projectId
+
+	var out Project
+
+	locator := LocatorIDInt(poolId).String()
+	err := s.restHelper.post(fmt.Sprintf("%s/projects", locator), project, &out, "Agent Pool")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Create will create an Agent Pool - which must have a unique name
 func (s *AgentPoolsService) Create(pool CreateAgentPool) (*AgentPool, error) {
 	var created AgentPool
@@ -100,6 +119,19 @@ func (s *AgentPoolsService) List() (*ListAgentPools, error) {
 	}
 
 	return &out, nil
+}
+
+// UnassignProject unassigns a Project from a Agent Pool
+func (s *AgentPoolsService) UnassignProject(poolId int, projectId string) error {
+	poolLocator := LocatorIDInt(poolId).String()
+	projectLocator := LocatorID(projectId).String()
+	uri := fmt.Sprintf("%s/projects/%s", poolLocator, projectLocator)
+	err := s.restHelper.delete(uri, "Agent Pool")
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // NOTE: Update support was investigated but is intentionally omitted - as the TC Documentation is incorrect

--- a/teamcity/agent_pool_test.go
+++ b/teamcity/agent_pool_test.go
@@ -23,6 +23,18 @@ func TestAgentPools_GetDefaultProject(t *testing.T) {
 	assert.True(len(retrievedPool.Projects.Project) == 1)
 }
 
+func TestAgentPools_GetDefaultProjectByName(t *testing.T) {
+	client := setup()
+	assert := assert.New(t)
+
+	retrievedPool, err := client.AgentPools.GetByName("Default")
+	assert.NoError(err)
+	assert.Equal(0, retrievedPool.Id)
+	assert.Equal("Default", retrievedPool.Name)
+	assert.Nil(retrievedPool.MaxAgents)
+	assert.True(len(retrievedPool.Projects.Project) == 1)
+}
+
 func TestAgentPools_Lifecycle(t *testing.T) {
 	client := setup()
 	assert := assert.New(t)

--- a/teamcity/agent_pool_test.go
+++ b/teamcity/agent_pool_test.go
@@ -16,7 +16,7 @@ func TestAgentPools_GetDefaultProject(t *testing.T) {
 	// this is hard-coded in TeamCity so we may as well do the same
 	defaultAgentPoolId := 0
 
-	retrievedPool, err := client.AgentPools.Get(defaultAgentPoolId)
+	retrievedPool, err := client.AgentPools.GetByID(defaultAgentPoolId)
 	assert.NoError(err)
 	assert.Equal("Default", retrievedPool.Name)
 	assert.Nil(retrievedPool.MaxAgents)
@@ -35,7 +35,7 @@ func TestAgentPools_Lifecycle(t *testing.T) {
 	assert.NotEmpty(createdPool.Id)
 	assert.Equal(agentPool.Name, createdPool.Name)
 
-	retrievedPool, err := client.AgentPools.Get(createdPool.Id)
+	retrievedPool, err := client.AgentPools.GetByID(createdPool.Id)
 	assert.NoError(err)
 	assert.Equal(agentPool.Name, retrievedPool.Name)
 	assert.Nil(retrievedPool.MaxAgents)
@@ -78,7 +78,7 @@ func TestAgentPools_ProjectAssignment(t *testing.T) {
 	assert := assert.New(t)
 
 	var validateContainsProject = func(poolId int, projectId string) bool {
-		agentPool, err := client.AgentPools.Get(poolId)
+		agentPool, err := client.AgentPools.GetByID(poolId)
 		assert.NoError(err)
 
 		if agentPool.Projects == nil {
@@ -110,7 +110,7 @@ func TestAgentPools_ProjectAssignment(t *testing.T) {
 	assert.NotEmpty(createdPool.Id)
 	assert.Equal(agentPool.Name, createdPool.Name)
 
-	retrievedPool, err := client.AgentPools.Get(createdPool.Id)
+	retrievedPool, err := client.AgentPools.GetByID(createdPool.Id)
 	assert.NoError(err)
 	assert.Equal(agentPool.Name, retrievedPool.Name)
 	assert.Nil(retrievedPool.MaxAgents)

--- a/teamcity/agent_pool_test.go
+++ b/teamcity/agent_pool_test.go
@@ -32,7 +32,6 @@ func TestAgentPools_GetDefaultProjectByName(t *testing.T) {
 	assert.Equal(0, retrievedPool.Id)
 	assert.Equal("Default", retrievedPool.Name)
 	assert.Nil(retrievedPool.MaxAgents)
-	assert.True(len(retrievedPool.Projects.Project) == 1)
 }
 
 func TestAgentPools_Lifecycle(t *testing.T) {

--- a/teamcity/agent_pool_test.go
+++ b/teamcity/agent_pool_test.go
@@ -9,6 +9,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestAgentPools_GetDefaultProject(t *testing.T) {
+	client := setup()
+	assert := assert.New(t)
+
+	// this is hard-coded in TeamCity so we may as well do the same
+	defaultAgentPoolId := 0
+
+	retrievedPool, err := client.AgentPools.Get(defaultAgentPoolId)
+	assert.NoError(err)
+	assert.Equal("Default", retrievedPool.Name)
+	assert.Nil(retrievedPool.MaxAgents)
+	assert.True(len(retrievedPool.Projects.Project) == 1)
+}
+
 func TestAgentPools_Lifecycle(t *testing.T) {
 	client := setup()
 	assert := assert.New(t)
@@ -36,20 +50,6 @@ func TestAgentPools_Lifecycle(t *testing.T) {
 			t.Fatalf("Created agent pool still exists!")
 		}
 	}
-}
-
-func TestAgentPools_GetDefaultProject(t *testing.T) {
-	client := setup()
-	assert := assert.New(t)
-
-	// this is hard-coded in TeamCity so we may as well do the same
-	defaultAgentPoolId := 0
-
-	retrievedPool, err := client.AgentPools.Get(defaultAgentPoolId)
-	assert.NoError(err)
-	assert.Equal("Default", retrievedPool.Name)
-	assert.Nil(retrievedPool.MaxAgents)
-	assert.True(len(retrievedPool.Projects.Project) == 1)
 }
 
 func TestAgentPools_List(t *testing.T) {

--- a/teamcity/agent_pool_test.go
+++ b/teamcity/agent_pool_test.go
@@ -13,7 +13,7 @@ func TestAgentPools_Lifecycle(t *testing.T) {
 	client := setup()
 	assert := assert.New(t)
 
-	agentPool := teamcity.AgentPool{
+	agentPool := teamcity.CreateAgentPool{
 		Name: fmt.Sprintf("test-%d", time.Now().Unix()),
 	}
 	createdPool, err := client.AgentPools.Create(agentPool)
@@ -38,6 +38,20 @@ func TestAgentPools_Lifecycle(t *testing.T) {
 	}
 }
 
+func TestAgentPools_GetDefaultProject(t *testing.T) {
+	client := setup()
+	assert := assert.New(t)
+
+	// this is hard-coded in TeamCity so we may as well do the same
+	defaultAgentPoolId := 0
+
+	retrievedPool, err := client.AgentPools.Get(defaultAgentPoolId)
+	assert.NoError(err)
+	assert.Equal("Default", retrievedPool.Name)
+	assert.Nil(retrievedPool.MaxAgents)
+	assert.True(len(retrievedPool.Projects.Project) == 1)
+}
+
 func TestAgentPools_List(t *testing.T) {
 	client := setup()
 	assert := assert.New(t)
@@ -56,5 +70,5 @@ func TestAgentPools_List(t *testing.T) {
 		}
 	}
 
-	assert.True(found, "Default agent pool was not found")
+	assert.True(found, "Default Agent Pool was not found")
 }

--- a/teamcity/agent_pool_test.go
+++ b/teamcity/agent_pool_test.go
@@ -1,0 +1,28 @@
+package teamcity_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAgentPools_List(t *testing.T) {
+	client := setup()
+	assert := assert.New(t)
+
+	agentPools, err := client.AgentPools.List()
+	assert.NoError(err)
+
+	// whilst other pools may have been added by other tests - the Default pool
+	// cannot be removed, so can be used as test data
+	assert.True(len(agentPools.AgentPools) > 0, "At least one agent pool should exist")
+
+	found := false
+	for _, pool := range agentPools.AgentPools {
+		if pool.Name == "Default" {
+			found = true
+		}
+	}
+
+	assert.True(found, "Default agent pool was not found")
+}

--- a/teamcity/locator.go
+++ b/teamcity/locator.go
@@ -1,6 +1,9 @@
 package teamcity
 
-import "net/url"
+import (
+	"fmt"
+	"net/url"
+)
 
 //Locator represents a arbitraty locator to be used when querying resources, such as id:, type:, or key:
 //These are used in GET requests within the URL so must be properly escaped
@@ -9,6 +12,11 @@ type Locator string
 //LocatorID creates a locator for a Project/BuildType by Id
 func LocatorID(id string) Locator {
 	return Locator(url.QueryEscape("id:") + id)
+}
+
+//LocatorIDInt creates a locator for a Project/BuildType by Id where the Id's an integer
+func LocatorIDInt(id int) Locator {
+	return Locator(url.QueryEscape("id:") + fmt.Sprintf("%d", id))
 }
 
 //LocatorName creates a locator for Project/BuildType by Name

--- a/teamcity/teamcity.go
+++ b/teamcity/teamcity.go
@@ -10,8 +10,9 @@ import (
 	"time"
 
 	"github.com/dghubble/sling"
+	// goimports has a bug which attempts to remove this if unaliased
+	loghttp "github.com/motemen/go-loghttp"
 
-	"github.com/motemen/go-loghttp"
 	// Enable HTTP log tracing
 	_ "github.com/motemen/go-loghttp/global"
 )
@@ -61,11 +62,12 @@ type Client struct {
 
 	commonBase *sling.Sling
 
-	Projects   *ProjectService
+	AgentPools *AgentPoolsService
 	BuildTypes *BuildTypeService
+	Groups     *GroupService
+	Projects   *ProjectService
 	Server     *ServerService
 	VcsRoots   *VcsRootService
-	Groups     *GroupService
 }
 
 func NewClient(auth Auth, httpClient *http.Client) (*Client, error) {
@@ -108,11 +110,12 @@ func newClientInstance(auth Auth, address string, httpClient *http.Client) (*Cli
 		address:    address,
 		HTTPClient: httpClient,
 		commonBase: sharedClient,
-		Projects:   newProjectService(sharedClient.New(), httpClient),
+		AgentPools: newAgentPoolsService(sharedClient.New(), httpClient),
 		BuildTypes: newBuildTypeService(sharedClient.New(), httpClient),
+		Groups:     newGroupService(sharedClient.New(), httpClient),
+		Projects:   newProjectService(sharedClient.New(), httpClient),
 		Server:     newServerService(sharedClient.New()),
 		VcsRoots:   newVcsRootService(sharedClient.New(), httpClient),
-		Groups:     newGroupService(sharedClient.New(), httpClient),
 	}, nil
 }
 


### PR DESCRIPTION
This PR contains support for managing Agent Pools & support for assigning/unassigning projects from said pools.

Whilst the documentation says [it's possible to update Agent Pools](https://www.jetbrains.com/help/teamcity/2019.2/rest-api.html#RESTAPI-AgentPools
  teamcity_agent_pool) - it appears unfortunately this isn't possible:

```
$ curl -v -u admin:admin http://localhost:8112/app/rest/agentPools/id:17 -X PUT --header "Content-Type: text/json" --data "{\"name\": \"test2\",\"id\":17,\"href\":\"/app/rest/agentPools/id:17\"}"
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8112 (#0)
* Server auth using Basic with user 'admin'
> PUT /app/rest/agentPools/id:17 HTTP/1.1
> Host: localhost:8112
> Authorization: Basic YWRtaW46YWRtaW4=
> User-Agent: curl/7.64.1
> Accept: */*
> Content-Type: text/json
> Content-Length: 61
>
* upload completely sent off: 61 out of 61 bytes
< HTTP/1.1 405
< TeamCity-Node-Id: MAIN_SERVER
< Set-Cookie: TCSESSIONID=0644DB19B150C1D555A4B850459B11F2; Path=/; HttpOnly
< Set-Cookie: RememberMe=; Max-Age=0; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; HttpOnly
< Cache-Control: no-store
< Content-Type: text/plain
< Transfer-Encoding: chunked
< Date: Thu, 23 Apr 2020 09:22:26 GMT
<
Responding with error, status code: 405.
Details: javax.ws.rs.WebApplicationException
* Connection #0 to host localhost left intact
Not supported request. Check that URL, HTTP method and transferred data are correct. Metadata: Allow:[HEAD,DELETE,GET,OPTIONS]* Closing connection 0
```

I've also checked without the ID using a POST, but that ends up creating a new pool/a PUT gets rejected there too ¯\_(ツ)_/¯

As such - I've not implemented Update support for now because it doesn't appear to be possible?