### PR TITLE
project: support for updating the name

### DIFF
--- a/teamcity/project.go
+++ b/teamcity/project.go
@@ -152,8 +152,12 @@ func (s *ProjectService) Delete(id string) error {
 }
 
 func (s *ProjectService) updateProject(project *Project, isCreate bool) (*Project, error) {
-	_, err := s.restHelper.putTextPlain(project.ID+"/description", project.Description, "project description")
+	_, err := s.restHelper.putTextPlain(project.ID+"/name", project.Name, "project name")
+	if err != nil {
+		return nil, err
+	}
 
+	_, err = s.restHelper.putTextPlain(project.ID+"/description", project.Description, "project description")
 	if err != nil {
 		return nil, err
 	}

--- a/teamcity/project_test.go
+++ b/teamcity/project_test.go
@@ -66,6 +66,27 @@ func TestProject_UpdateWithSameParentDoesNotChangeName(t *testing.T) {
 	assert.Equal(t, "ChildProject", updated.Name)
 }
 
+func TestProject_UpdateName(t *testing.T) {
+	parent, _ := teamcity.NewProject("ParentProject", "Parent Project", "")
+	child, _ := teamcity.NewProject("ChildProject", "Child Project", "ParentProject")
+
+	client := setup()
+
+	_, err := client.Projects.Create(parent)
+	require.NoError(t, err)
+	defer cleanUpProject(t, client, "ParentProject")
+
+	created, err := client.Projects.Create(child)
+	require.NoError(t, err)
+
+	actual, _ := client.Projects.GetByID(created.ID)
+	actual.Name = "Updated"
+	updated, _ := client.Projects.Update(actual)
+
+	assert.Equal(t, "Updated", updated.Name)
+	assert.Equal(t, parent.ID, updated.ParentProjectID)
+}
+
 func TestProject_UpdateParent(t *testing.T) {
 	parent, _ := teamcity.NewProject(testProjectId, "Parent Project", "")
 	newParent, _ := teamcity.NewProject("NewParent", "NewParent Project", "")

--- a/teamcity/project_test.go
+++ b/teamcity/project_test.go
@@ -79,9 +79,28 @@ func TestProject_UpdateName(t *testing.T) {
 
 	actual, _ := client.Projects.GetByID(created.ID)
 	actual.Name = fmt.Sprintf("Updated %s", projectName)
-	updated, _ := client.Projects.Update(actual)
+	_, _ = client.Projects.Update(actual)
 
-	assert.Equal(t, fmt.Sprintf("Updated %s", projectName), updated.Name)
+	actual, _ = client.Projects.GetByID(created.ID)
+	assert.Equal(t, fmt.Sprintf("Updated %s", projectName), actual.Name)
+}
+
+func TestProject_UpdateDescription(t *testing.T) {
+	projectName := fmt.Sprintf("Project %d", time.Now().Unix())
+	project, _ := teamcity.NewProject(projectName, "", "")
+
+	client := setup()
+
+	created, err := client.Projects.Create(project)
+	require.NoError(t, err)
+	defer cleanUpProject(t, client, created.ID)
+
+	actual, _ := client.Projects.GetByID(created.ID)
+	actual.Description = "Updated Description"
+	_, _ = client.Projects.Update(actual)
+
+	actual, _ = client.Projects.GetByID(created.ID)
+	assert.Equal(t, "Updated Description", actual.Description)
 }
 
 func TestProject_UpdateParent(t *testing.T) {

--- a/teamcity/project_test.go
+++ b/teamcity/project_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/cvbarros/go-teamcity/teamcity"
 	"github.com/stretchr/testify/assert"
@@ -67,24 +68,20 @@ func TestProject_UpdateWithSameParentDoesNotChangeName(t *testing.T) {
 }
 
 func TestProject_UpdateName(t *testing.T) {
-	parent, _ := teamcity.NewProject("ParentProject", "Parent Project", "")
-	child, _ := teamcity.NewProject("ChildProject", "Child Project", "ParentProject")
+	projectName := fmt.Sprintf("Project %d", time.Now().Unix())
+	project, _ := teamcity.NewProject(projectName, "", "")
 
 	client := setup()
 
-	_, err := client.Projects.Create(parent)
+	created, err := client.Projects.Create(project)
 	require.NoError(t, err)
-	defer cleanUpProject(t, client, "ParentProject")
-
-	created, err := client.Projects.Create(child)
-	require.NoError(t, err)
+	defer cleanUpProject(t, client, created.ID)
 
 	actual, _ := client.Projects.GetByID(created.ID)
-	actual.Name = "Updated"
+	actual.Name = fmt.Sprintf("Updated %s", projectName)
 	updated, _ := client.Projects.Update(actual)
 
-	assert.Equal(t, "Updated", updated.Name)
-	assert.Equal(t, parent.ID, updated.ParentProjectID)
+	assert.Equal(t, fmt.Sprintf("Updated %s", projectName), updated.Name)
 }
 
 func TestProject_UpdateParent(t *testing.T) {


### PR DESCRIPTION
This PR adds support for updating the name of a project, which means it's possible to update this without recreating it - supported via the `/name` endpoint: https://www.jetbrains.com/help/teamcity/2019.2/rest-api.html#RESTAPI-ProjectSettings