### PR TITLE
build-type: support updating the `name` field

### DIFF
--- a/teamcity/build_type.go
+++ b/teamcity/build_type.go
@@ -261,11 +261,15 @@ func (s *BuildTypeService) GetByID(id string) (*BuildType, error) {
 }
 
 //Update changes the resource in-place for this build configuration.
-//TeamCity API does not support "PUT" on the whole Build Configuration resource, so the only updateable field is "Description". Other field updates will be ignored.
+//TeamCity API does not support "PUT" on the whole Build Configuration resource, so the only updateable fields are "Name" and "Description". Other field updates will be ignored.
 //This method also updates Settings and Parameters, but this is not an atomic operation. If an error occurs, it will be returned to caller what was updated or not.
 func (s *BuildTypeService) Update(buildType *BuildType) (*BuildType, error) {
-	_, err := s.restHelper.putTextPlain(buildType.ID+"/description", buildType.Description, "build type description")
+	_, err := s.restHelper.putTextPlain(buildType.ID+"/name", buildType.Name, "build type name")
+	if err != nil {
+		return nil, err
+	}
 
+	_, err = s.restHelper.putTextPlain(buildType.ID+"/description", buildType.Description, "build type description")
 	if err != nil {
 		return nil, err
 	}

--- a/teamcity/build_type_test.go
+++ b/teamcity/build_type_test.go
@@ -101,6 +101,7 @@ func TestBuildType_Update(t *testing.T) {
 	actual, err := sut.GetByID(created.ID) //Refresh
 
 	//Update some fields
+	actual.Name = "Updated name"
 	actual.Description = "Updated description"
 	actual.Options.ArtifactRules = []string{"rule1", "rule2"}
 	actual.Options.BuildCounter = 10
@@ -111,6 +112,7 @@ func TestBuildType_Update(t *testing.T) {
 
 	require.NoError(t, err)
 
+	assert.Equal("Updated name", updated.Name)
 	assert.Equal("Updated description", updated.Description)
 	assert.Equal([]string{"rule1", "rule2"}, updated.Options.ArtifactRules)
 	assert.Equal(10, updated.Options.BuildCounter)


### PR DESCRIPTION
After trial-and-error it appears this can also be updated via the API but it's not documented - but this follows the same convention as Projects