### PR TITLE
Add Project Connection setup for Vault OAuth provider.

### DIFF
--- a/teamcity/project_feature.go
+++ b/teamcity/project_feature.go
@@ -52,7 +52,7 @@ func (s *ProjectFeatureService) Create(feature ProjectFeature) (ProjectFeature, 
 		return nil, fmt.Errorf("feature is nil")
 	}
 	if feature.ProjectID() != s.ProjectID {
-		return nil, fmt.Errorf("given ProjectFeature for project %q to ProjectFeatureService for project %q.", feature.ProjectID(), s.ProjectID)
+		return nil, fmt.Errorf("given ProjectFeature for project %q to ProjectFeatureService for project %q", feature.ProjectID(), s.ProjectID)
 	}
 
 	requestBody := &projectFeatureJSON{
@@ -152,6 +152,8 @@ func (s *ProjectFeatureService) Update(feature ProjectFeature) (ProjectFeature, 
 
 func (s *ProjectFeatureService) parseProjectFeatureJSONResponse(feature projectFeatureJSON) (ProjectFeature, error) {
 	switch feature.Type {
+	case "OAuthProvider":
+		return loadConnectionProviderVault(s.ProjectID, feature)
 	case "versionedSettings":
 		return loadProjectFeatureVersionedSettings(s.ProjectID, feature)
 	default:

--- a/teamcity/project_feature_connection.go
+++ b/teamcity/project_feature_connection.go
@@ -1,0 +1,161 @@
+package teamcity
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// ConnectionType represents the TeamCity connection type
+type ConnectionType string
+
+const (
+	// ConnectionTypeOAuthProvider resprents an OAuth Provider connection type
+	ConnectionTypeOAuthProvider ConnectionType = "OAuthProvider"
+)
+
+// ConnectionProviderType represents the OAuth provider type
+type ConnectionProviderType string
+
+const (
+	// ConnectionProviderTypeVault represents an Hashicorp Vault provider type
+	ConnectionProviderTypeVault ConnectionProviderType = "teamcity-vault"
+)
+
+// ConnectionProviderVaultAuthMethod represents the Vault auth method
+type ConnectionProviderVaultAuthMethod string
+
+const (
+	// ConnectionProviderVaultAuthMethodIAM represents the IAM auth method
+	ConnectionProviderVaultAuthMethodIAM ConnectionProviderVaultAuthMethod = "iam"
+	// ConnectionProviderVaultAuthMethodApprole represents the approle auth method
+	ConnectionProviderVaultAuthMethodApprole ConnectionProviderVaultAuthMethod = "approle"
+)
+
+// ConnectionProviderVaultOptions is the required options for the Vault OAuth provider
+type ConnectionProviderVaultOptions struct {
+	AuthMethod     ConnectionProviderVaultAuthMethod
+	DisplayName    string
+	Endpoint       string
+	FailOnError    bool
+	Namespace      string
+	ProviderType   ConnectionProviderType
+	RoleID         string
+	SecretID       string
+	URL            string
+	VaultNamespace string
+}
+
+// ConnectionProviderVault defines the Vault Connection details
+type ConnectionProviderVault struct {
+	id        string
+	projectID string
+
+	Options ConnectionProviderVaultOptions
+}
+
+// NewProjectConnectionVault creates a new Vault OAuth Provider connection feature
+func NewProjectConnectionVault(projectID string, options ConnectionProviderVaultOptions) *ConnectionProviderVault {
+	return &ConnectionProviderVault{
+		projectID: projectID,
+		Options:   options,
+	}
+}
+
+// ID returns the ID of this project feature
+func (f *ConnectionProviderVault) ID() string {
+	return f.id
+}
+
+// SetID sets the ID of this project feature
+func (f *ConnectionProviderVault) SetID(value string) {
+	f.id = value
+}
+
+// Type represents the type of this project feature as a string
+func (f *ConnectionProviderVault) Type() string {
+	return "OAuthProvider"
+}
+
+// ProjectID represents the ID of the project the project feature is assigned to.
+func (f *ConnectionProviderVault) ProjectID() string {
+	return f.projectID
+}
+
+// SetProjectID sets the ID of the project the project feature is assigned to.
+func (f *ConnectionProviderVault) SetProjectID(value string) {
+	f.projectID = value
+}
+
+// Properties returns all properties for the Vault OAuth Provider project feature
+func (f *ConnectionProviderVault) Properties() *Properties {
+	return NewProperties(
+		NewProperty("auth-method", string(f.Options.AuthMethod)),
+		NewProperty("displayName", string(f.Options.DisplayName)),
+		NewProperty("endpoint", string(f.Options.Endpoint)),
+		NewProperty("fail-on-error", fmt.Sprintf("%t", f.Options.FailOnError)),
+		NewProperty("namespace", string(f.Options.Namespace)),
+		NewProperty("providerType", string(ConnectionProviderTypeVault)),
+		NewProperty("role-id", string(f.Options.RoleID)),
+		NewProperty("secure:secret-id", string(f.Options.SecretID)),
+		NewProperty("url", string(f.Options.URL)),
+		NewProperty("vault-namespace", string(f.Options.VaultNamespace)),
+	)
+}
+
+func loadConnectionProviderVault(projectID string, feature projectFeatureJSON) (ProjectFeature, error) {
+	settings := &ConnectionProviderVault{
+		id:        feature.ID,
+		projectID: projectID,
+		Options:   ConnectionProviderVaultOptions{},
+	}
+
+	// stringProperties := []string{"displayName", "endpoint", "namespace", "role-id", "url", "vault-namespace"}
+	// for _, property := range stringProperties {
+	// 	if encodedValue, ok := feature.Properties.GetOk("displayName"); ok {
+	// 		settings.Options.DisplayName = encodedValue
+	// 	}
+	// }
+
+	if encodedValue, ok := feature.Properties.GetOk("displayName"); ok {
+		settings.Options.DisplayName = encodedValue
+	}
+
+	if encodedValue, ok := feature.Properties.GetOk("endpoint"); ok {
+		settings.Options.Endpoint = encodedValue
+	}
+
+	if encodedValue, ok := feature.Properties.GetOk("namespace"); ok {
+		settings.Options.Namespace = encodedValue
+	}
+
+	if encodedValue, ok := feature.Properties.GetOk("role-id"); ok {
+		settings.Options.RoleID = encodedValue
+	}
+
+	if encodedValue, ok := feature.Properties.GetOk("url"); ok {
+		settings.Options.URL = encodedValue
+	}
+
+	if encodedValue, ok := feature.Properties.GetOk("vault-namespace"); ok {
+		settings.Options.VaultNamespace = encodedValue
+	}
+
+	if encodedValue, ok := feature.Properties.GetOk("fail-on-error"); ok {
+		v, err := strconv.ParseBool(encodedValue)
+		if err != nil {
+			return nil, err
+		}
+
+		settings.Options.FailOnError = v
+	}
+
+	if encodedValue, ok := feature.Properties.GetOk("auth-method"); ok {
+		settings.Options.AuthMethod = ConnectionProviderVaultAuthMethod(encodedValue)
+	}
+
+	if encodedValue, ok := feature.Properties.GetOk("providerType"); ok {
+		settings.Options.ProviderType = ConnectionProviderType(encodedValue)
+	}
+
+	return settings, nil
+}

--- a/teamcity/project_feature_connection_test.go
+++ b/teamcity/project_feature_connection_test.go
@@ -1,0 +1,60 @@
+package teamcity_test
+
+import (
+	"testing"
+
+	"github.com/cvbarros/go-teamcity/teamcity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectFeatureConnection_CreateVault(t *testing.T) {
+	client := safeSetup(t)
+
+	project := createTestProjectWithImplicitName(t, client)
+	defer cleanUpProject(t, client, project.ID)
+
+	service := client.ProjectFeatureService(project.ID)
+
+	feature := teamcity.NewProjectConnectionVault(project.ID, teamcity.ConnectionProviderVaultOptions{
+		AuthMethod:  "approle",
+		DisplayName: "Hashicorp Vault",
+		Endpoint:    "approle",
+		RoleID:      "123456",
+		SecretID:    "abcdefg",
+		URL:         "http://vault.service:8200",
+	})
+
+	createdFeature, err := service.Create(feature)
+	require.NoError(t, err)
+	assert.NotEmpty(t, createdFeature.ID())
+}
+
+func TestProjectFeatureConnection_DeleteVault(t *testing.T) {
+	client := safeSetup(t)
+
+	project := createTestProjectWithImplicitName(t, client)
+	defer cleanUpProject(t, client, project.ID)
+
+	service := client.ProjectFeatureService(project.ID)
+
+	feature := teamcity.NewProjectConnectionVault(project.ID, teamcity.ConnectionProviderVaultOptions{
+		AuthMethod:  "approle",
+		DisplayName: "Hashicorp Vault",
+		Endpoint:    "approle",
+		RoleID:      "123456",
+		SecretID:    "abcdefg",
+		URL:         "http://vault.service:8200",
+	})
+
+	createdFeature, err := service.Create(feature)
+	require.NoError(t, err)
+	assert.NotEmpty(t, createdFeature.ID())
+
+	err = service.Delete(createdFeature.ID())
+	require.NoError(t, err)
+
+	deletedFeature, err := service.GetByID(createdFeature.ID())
+	assert.NotNil(t, err)
+	assert.Nil(t, deletedFeature)
+}


### PR DESCRIPTION
This is an initial commit adding support for managing Hashicorp
Vault OAuthProvider connections.

N.B: This requires the `HashiCorp Vault Support` plugin is installed
within TeamCity
