### PR TITLE
Add support for Google Cloud Profiles

### DIFF
--- a/teamcity/project_feature.go
+++ b/teamcity/project_feature.go
@@ -154,6 +154,8 @@ func (s *ProjectFeatureService) parseProjectFeatureJSONResponse(feature projectF
 	switch feature.Type {
 	case "versionedSettings":
 		return loadProjectFeatureVersionedSettings(s.ProjectID, feature)
+	case "CloudProfile":
+		return loadProjectFeatureGoogleCloudProfile(s.ProjectID, feature)
 	default:
 		return nil, fmt.Errorf("Unknown project feature type %q", feature.Type)
 	}

--- a/teamcity/project_feature_google_cloud_profile.go
+++ b/teamcity/project_feature_google_cloud_profile.go
@@ -1,0 +1,79 @@
+package teamcity
+
+// ProjectFeatureGoogleCloudProfileOptions represents the options available on Google Cloud Profiles
+type ProjectFeatureGoogleCloudProfileOptions struct {
+	Enabled             bool   `prop:"enabled"`
+	ProfileID           string `prop:"profileId"`
+	Name                string `prop:"name"`
+	Description         string `prop:"description"`
+	CloudCode           string `prop:"cloud-code"`
+	ProfileServerURL    string `prop:"profileServerUrl"`
+	AgentPushPreset     string `prop:"agentPushPreset"` //
+	TotalWorkTime       int    `prop:"total-work-time"`
+	CredentialsType     string `prop:"credentialsType"` // TODO "key"
+	NextHour            string `prop:"next-hour"`       // TODO
+	TerminateAfterBuild bool   `prop:"terminate-after-build"`
+	TerminateIdleTime   int    `prop:"terminate-idle-time"`
+	AccessKey           string `prop:"secure:accessKey"`
+}
+
+// ProjectFeatureGoogleCloudProfile represents the Google Cloud Profile feature for a project.
+type ProjectFeatureGoogleCloudProfile struct {
+	id        string
+	projectID string
+
+	Options ProjectFeatureGoogleCloudProfileOptions
+}
+
+// NewProjectFeatureGoogleCloudProfile creates a new Google Cloud Profile project feature.
+func NewProjectFeatureGoogleCloudProfile(projectID string, options ProjectFeatureGoogleCloudProfileOptions) *ProjectFeatureGoogleCloudProfile {
+	options.CloudCode = "google"
+
+	return &ProjectFeatureGoogleCloudProfile{
+		projectID: projectID,
+		Options:   options,
+	}
+}
+
+// ID returns the Cloud Profile ID
+func (f *ProjectFeatureGoogleCloudProfile) ID() string {
+	return f.id
+}
+
+// SetID sets the Cloud Profile ID
+func (f *ProjectFeatureGoogleCloudProfile) SetID(value string) {
+	f.id = value
+}
+
+// Type returns the Feature type, which is always "CloudProfile"
+func (f *ProjectFeatureGoogleCloudProfile) Type() string {
+	return "CloudProfile"
+}
+
+// ProjectID returns the Project ID for the project to which this profile is attached
+func (f *ProjectFeatureGoogleCloudProfile) ProjectID() string {
+	return f.projectID
+}
+
+// SetProjectID sets the Project ID for the project to which this profile should be attached
+func (f *ProjectFeatureGoogleCloudProfile) SetProjectID(value string) {
+	f.projectID = value
+}
+
+// Properties returns a typed representation of the Properties of this profile
+func (f *ProjectFeatureGoogleCloudProfile) Properties() *Properties {
+	f.Options.CloudCode = "google"
+
+	return serializeToProperties(&f.Options)
+}
+
+func loadProjectFeatureGoogleCloudProfile(projectID string, feature projectFeatureJSON) (ProjectFeature, error) {
+	settings := &ProjectFeatureGoogleCloudProfile{
+		id:        feature.ID,
+		projectID: projectID,
+		Options:   ProjectFeatureGoogleCloudProfileOptions{},
+	}
+
+	fillStructFromProperties(&settings.Options, feature.Properties)
+	return settings, nil
+}

--- a/teamcity/project_feature_google_cloud_profile_test.go
+++ b/teamcity/project_feature_google_cloud_profile_test.go
@@ -1,0 +1,174 @@
+package teamcity_test
+
+import (
+	"testing"
+
+	"github.com/cvbarros/go-teamcity/teamcity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectFeature_CloudProfile_Create(t *testing.T) {
+	client := safeSetup(t)
+
+	project := createTestProjectWithImplicitName(t, client)
+	defer cleanUpProject(t, client, project.ID)
+
+	service := client.ProjectFeatureService(project.ID)
+
+	feature := teamcity.NewProjectFeatureGoogleCloudProfile(project.ID, teamcity.ProjectFeatureGoogleCloudProfileOptions{
+		Enabled:           true,
+		Name:              "Test",
+		CredentialsType:   "key",
+		TerminateIdleTime: 20,
+		TotalWorkTime:     20,
+	})
+
+	createdFeature, err := service.Create(feature)
+	require.NoError(t, err)
+	assert.NotEmpty(t, createdFeature.ID)
+}
+
+func TestProjectFeature_CloudProfile_Delete(t *testing.T) {
+	client := safeSetup(t)
+
+	project := createTestProjectWithImplicitName(t, client)
+	defer cleanUpProject(t, client, project.ID)
+
+	service := client.ProjectFeatureService(project.ID)
+
+	feature := teamcity.NewProjectFeatureGoogleCloudProfile(project.ID, teamcity.ProjectFeatureGoogleCloudProfileOptions{
+		Enabled:           true,
+		Name:              "Test",
+		CredentialsType:   "key",
+		TerminateIdleTime: 20,
+		TotalWorkTime:     20,
+	})
+
+	createdFeature, err := service.Create(feature)
+	require.NoError(t, err)
+	assert.NotEmpty(t, createdFeature.ID)
+
+	err = service.Delete(createdFeature.ID())
+	require.NoError(t, err)
+
+	deletedFeature, err := service.GetByID(createdFeature.ID())
+	assert.NotNil(t, err)
+	assert.Nil(t, deletedFeature)
+}
+
+func TestProjectFeature_GoogleCloudProfile_Update(t *testing.T) {
+	client := safeSetup(t)
+
+	project := createTestProjectWithImplicitName(t, client)
+	defer cleanUpProject(t, client, project.ID)
+
+	service := client.ProjectFeatureService(project.ID)
+
+	feature := teamcity.NewProjectFeatureGoogleCloudProfile(project.ID, teamcity.ProjectFeatureGoogleCloudProfileOptions{
+		Enabled:         true,
+		Name:            "Test Profile",
+		CredentialsType: "key",
+		AccessKey:       "",
+	})
+
+	createdFeature, err := service.Create(feature)
+	require.NoError(t, err)
+	assert.NotEmpty(t, createdFeature.ID)
+
+	type testData = struct {
+		Enabled             bool
+		ProfileID           string
+		Name                string
+		Description         string
+		CloudCode           string
+		ProfileServerURL    string
+		AgentPushPreset     string
+		TotalWorkTime       int
+		CredentialsType     string
+		NextHour            string
+		TerminateAfterBuild bool
+		TerminateIdleTime   int
+		AccessKey           string
+	}
+
+	var validate = func(t *testing.T, id string, data testData) {
+		retrievedFeature, err := service.GetByID(id)
+		require.NoError(t, err)
+		cloudProfile, ok := retrievedFeature.(*teamcity.ProjectFeatureGoogleCloudProfile)
+		assert.True(t, ok)
+
+		assert.Equal(t, data.Enabled, cloudProfile.Options.Enabled)
+		assert.Equal(t, data.Name, cloudProfile.Options.Name)
+		assert.Equal(t, data.Description, cloudProfile.Options.Description)
+		assert.Equal(t, data.CloudCode, cloudProfile.Options.CloudCode)
+		assert.Equal(t, data.ProfileServerURL, cloudProfile.Options.ProfileServerURL)
+		assert.Equal(t, data.AgentPushPreset, cloudProfile.Options.AgentPushPreset)
+		assert.Equal(t, data.TotalWorkTime, cloudProfile.Options.TotalWorkTime)
+		assert.Equal(t, data.CredentialsType, cloudProfile.Options.CredentialsType)
+		assert.Equal(t, data.NextHour, cloudProfile.Options.NextHour)
+		assert.Equal(t, data.TerminateAfterBuild, cloudProfile.Options.TerminateAfterBuild)
+		assert.Equal(t, data.TerminateIdleTime, cloudProfile.Options.TerminateIdleTime)
+		assert.Equal(t, data.AccessKey, cloudProfile.Options.AccessKey)
+	}
+	t.Log("Validating initial creation")
+	validate(t, createdFeature.ID(), testData{
+		Enabled:         true,
+		Name:            "Test Profile",
+		CloudCode:       "google",
+		CredentialsType: "key",
+	})
+
+	updateConfigurations := []testData{
+		{
+			Enabled:     false,
+			Name:        "Test Profile - Updated",
+			Description: "Changed Description / Enabled / Name",
+		},
+		{
+			Enabled:       true,
+			Name:          "Test Profile",
+			Description:   "Updating TotalWorkTime",
+			TotalWorkTime: 100,
+		},
+		{
+			Enabled:             true,
+			Name:                "Test Profile",
+			Description:         "Updating TerminateAfterBuild",
+			TerminateAfterBuild: true,
+		},
+	}
+	for _, update := range updateConfigurations {
+		t.Logf("Testing %q", update.Description)
+
+		existing, err := service.GetByID(createdFeature.ID())
+		require.NoError(t, err)
+
+		settings, ok := existing.(*teamcity.ProjectFeatureGoogleCloudProfile)
+		assert.True(t, ok)
+
+		update.ProfileID = settings.Options.ProfileID
+		update.CloudCode = settings.Options.CloudCode
+
+		settings.Options.Enabled = update.Enabled
+		settings.Options.Name = update.Name
+		settings.Options.Description = update.Description
+		settings.Options.ProfileServerURL = update.ProfileServerURL
+		settings.Options.AgentPushPreset = update.AgentPushPreset
+		settings.Options.TotalWorkTime = update.TotalWorkTime
+		settings.Options.CredentialsType = update.CredentialsType
+		settings.Options.NextHour = update.NextHour
+		settings.Options.TerminateAfterBuild = update.TerminateAfterBuild
+		settings.Options.TerminateIdleTime = update.TerminateIdleTime
+		settings.Options.AccessKey = update.AccessKey
+
+		updatedFeature, err := service.Update(settings)
+		require.NoError(t, err)
+		assert.NotEmpty(t, updatedFeature.ID)
+
+		// sanity check since we're updating with the same ID
+		assert.Equal(t, createdFeature.ID(), updatedFeature.ID())
+
+		validate(t, updatedFeature.ID(), update)
+	}
+}

--- a/teamcity/project_feature_google_cloud_profile_test.go
+++ b/teamcity/project_feature_google_cloud_profile_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProjectFeature_CloudProfile_Create(t *testing.T) {
+func TestProjectFeature_GoogleCloudProfile_Create(t *testing.T) {
 	client := safeSetup(t)
 
 	project := createTestProjectWithImplicitName(t, client)
@@ -29,7 +29,7 @@ func TestProjectFeature_CloudProfile_Create(t *testing.T) {
 	assert.NotEmpty(t, createdFeature.ID)
 }
 
-func TestProjectFeature_CloudProfile_Delete(t *testing.T) {
+func TestProjectFeature_GoogleCloudProfile_Delete(t *testing.T) {
 	client := safeSetup(t)
 
 	project := createTestProjectWithImplicitName(t, client)


### PR DESCRIPTION
I initially started with a more generic "Cloud Profiles" implementation, but, it turns out that the different Cloud plugins have different sets of options available on the Cloud Profile.